### PR TITLE
helper function tbl_sql compatibility

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -50,16 +50,16 @@ helper_list <- function(x, .data) {
   if(x[[1]] != "list" || length(x) > 3) {
     stop("as_survey_twophase requies a list of 2 sets of variables")
   }
-  name1 <- unname(dplyr::select_vars_(names(.data), x[[2]]))
+  name1 <- unname(dplyr::select_vars_(colnames(.data), x[[2]]))
   name1 <- if (length(name1) == 0) NULL else name1
-  name2 <- unname(dplyr::select_vars_(names(.data), x[[3]]))
+  name2 <- unname(dplyr::select_vars_(colnames(.data), x[[3]]))
   name2 <- if (length(name2) == 0) NULL else name2
   list(name1, name2)
 }
 
 # Need to turn bare variable to variable names (when not in list)
 helper <- function(x, .data) {
-  unname(dplyr::select_vars_(names(.data), x))
+  unname(dplyr::select_vars_(colnames(.data), x))
 }
 
 #' Pipe operator


### PR DESCRIPTION
hi, i don't think this change affects anything already implemented, but once you allow database-backed objects, colnames() gives the correct result here for `tbl_sql` objects as well as data.frames

to get something like this block working

	library(DBI)
	library(RSQLite)
	library(srvyr)
	library(dplyr)

	my_db <- src_sqlite(system.file("api.db",package="survey") )

	apiclus1 <- tbl(my_db, "apiclus1")

	dclus1 <- apiclus1 %>% as_survey_design(id=dnum, weights=pw, fpc=fpc)

i think you need a `as_tbl_sqlsvy` function that parallels `as_tbl_svy` but works on `tbl_sql` objects.  seems a bit challenging but would be awesome.  thanks for the great work