### PR TITLE
Update rlang compat files

### DIFF
--- a/R/rlang-compat-lazyeval.R
+++ b/R/rlang-compat-lazyeval.R
@@ -1,4 +1,4 @@
-# nocov start - compat-lazyeval (last updated: rlang 0.1.9000)
+# nocov start - compat-lazyeval (last updated: rlang 0.3.0)
 
 # This file serves as a reference for compatibility functions for lazyeval.
 # Please find the most recent version in rlang's repository.
@@ -23,30 +23,40 @@ compat_lazy <- function(lazy, env = caller_env(), warn = TRUE) {
   if (missing(lazy)) {
     return(quo())
   }
+  if (is_quosure(lazy)) {
+    return(lazy)
+  }
+  if (is_formula(lazy)) {
+    return(as_quosure(lazy, env))
+  }
 
-  coerce_type(lazy, "a quosure",
-              formula = as_quosure(lazy, env),
-              symbol = ,
-              language = new_quosure(lazy, env),
-              string = ,
-              character = {
-                if (warn) warn_text_se()
-                parse_quosure(lazy[[1]], env)
-              },
-              logical = ,
-              integer = ,
-              double = {
-                if (length(lazy) > 1) {
-                  warn("Truncating vector to length 1")
-                  lazy <- lazy[[1]]
-                }
-                new_quosure(lazy, env)
-              },
-              list =
-                coerce_class(lazy, "a quosure",
-                             lazy = new_quosure(lazy$expr, lazy$env)
-                )
+  out <- switch(typeof(lazy),
+    symbol = ,
+    language = new_quosure(lazy, env),
+    character = {
+      if (warn) warn_text_se()
+      parse_quo(lazy[[1]], env)
+    },
+    logical = ,
+    integer = ,
+    double = {
+      if (length(lazy) > 1) {
+        warn("Truncating vector to length 1")
+        lazy <- lazy[[1]]
+      }
+      new_quosure(lazy, env)
+    },
+    list =
+      if (inherits(lazy, "lazy")) {
+        lazy = new_quosure(lazy$expr, lazy$env)
+      }
   )
+
+  if (is_null(out)) {
+    abort(sprintf("Can't convert a %s to a quosure", typeof(lazy)))
+  } else {
+    out
+  }
 }
 
 compat_lazy_dots <- function(dots, env, ..., .named = FALSE) {
@@ -68,7 +78,7 @@ compat_lazy_dots <- function(dots, env, ..., .named = FALSE) {
 
   named <- have_name(dots)
   if (.named && any(!named)) {
-    nms <- map_chr(dots[!named], f_text)
+    nms <- vapply(dots[!named], function(x) expr_text(get_expr(x)), character(1))
     names(dots)[!named] <- nms
   }
 
@@ -78,12 +88,12 @@ compat_lazy_dots <- function(dots, env, ..., .named = FALSE) {
 
 compat_as_lazy <- function(quo) {
   structure(class = "lazy", list(
-    expr = f_rhs(quo),
-    env = f_env(quo)
+    expr = get_expr(quo),
+    env = get_env(quo)
   ))
 }
 compat_as_lazy_dots <- function(...) {
-  structure(class = "lazy_dots", map(quos(...), compat_as_lazy))
+  structure(class = "lazy_dots", lapply(quos(...), compat_as_lazy))
 }
 
 

--- a/R/rlang-compat-purrr.R
+++ b/R/rlang-compat-purrr.R
@@ -1,4 +1,4 @@
-# nocov start - compat-purrr (last updated: rlang 0.1.9000)
+# nocov start - compat-purrr (last updated: rlang 0.3.0)
 
 # This file serves as a reference for compatibility functions for
 # purrr. They are not drop-in replacements but allow a similar style
@@ -50,7 +50,7 @@ pluck_cpl <- function(.x, .f) {
 }
 
 map2 <- function(.x, .y, .f, ...) {
-  Map(.f, .x, .y, ...)
+  mapply(.f, .x, .y, MoreArgs = list(...), SIMPLIFY = FALSE)
 }
 map2_lgl <- function(.x, .y, .f, ...) {
   as.vector(map2(.x, .y, .f, ...), "logical")
@@ -158,5 +158,30 @@ accumulate_right <- function(.x, .f, ..., .init) {
   f <- function(x, y) .f(y, x, ...)
   Reduce(f, .x, init = .init, right = TRUE, accumulate = TRUE)
 }
+
+detect <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
+  for (i in index(.x, .right)) {
+    if (.p(.f(.x[[i]], ...))) {
+      return(.x[[i]])
+    }
+  }
+  NULL
+}
+detect_index <- function(.x, .f, ..., .right = FALSE, .p = is_true) {
+  for (i in index(.x, .right)) {
+    if (.p(.f(.x[[i]], ...))) {
+      return(i)
+    }
+  }
+  0L
+}
+index <- function(x, right = FALSE) {
+  idx <- seq_along(x)
+  if (right) {
+    idx <- rev(idx)
+  }
+  idx
+}
+
 
 # nocov end


### PR DESCRIPTION
This fixes some issues and also avoids using soft-deprecated `parse_quosure()` function.