### PR TITLE
Update usage of deprecated functions from dplyr

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Imports:
     magrittr,
     rlang,
     survey,
-    tibble
+    tibble,
+    tidyselect
 License: GPL-2 | GPL-3
 LazyData: TRUE
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Version: 0.3.4.9002
 Date: 2019-01-19
 Authors@R: c(person("Greg", "Freedman Ellis", email = "greg.freedman@gmail.com", role = c("aut", "cre")),
   person("Thomas", "Lumley", role = "ctb"),
-  person("Tomasz", "\u017b\u00F3\u0142tak", role = "ctb"))
+  person("Tomasz", "\u017b\u00F3\u0142tak", role = "ctb"),
+  person("Ben", "Schneider", role = "ctb"))
 URL: http://gdfe.co/srvyr, https://github.com/gergness/srvyr
 BugReports: https://github.com/gergness/srvyr/issues
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
   
 * Removed references to MonetDBLite since it has been removed from CRAN.
 
+* Small updates to replace soft-deprecated dplyr functions with their tibble
+  and tidyselect equivalents.
+
 # srvyr 0.3.4
 * survey_mean/survey_total allow `deff="replace"` like their survey package
   forbearers. (#46, thanks @mandes95)

--- a/R/as_survey_rep.r
+++ b/R/as_survey_rep.r
@@ -167,7 +167,7 @@ as_survey_rep.survey.design2 <-
                             compress = compress, mse = mse)
 
     class(.data) <- c("tbl_svy", class(.data))
-    .data$variables <- dplyr::tbl_df(.data$variables)
+    .data$variables <- tibble::as_tibble(.data$variables)
 
     as_tbl_svy(.data)
   }

--- a/R/summarise.r
+++ b/R/summarise.r
@@ -18,7 +18,7 @@ summarise.tbl_svy <- function(.data, ...) {
   })
 
   out <- dplyr::bind_cols(out)
-  dplyr::tbl_df(out)
+  tibble::as_tibble(out)
 }
 
 #' @export
@@ -55,7 +55,7 @@ summarise.grouped_svy <- function(.data, ...) {
   })
 
   out <- dplyr::bind_cols(out)
-  dplyr::tbl_df(out)
+  tibble::as_tibble(out)
 }
 
 #' @export

--- a/R/survey_statistics_helpers.R
+++ b/R/survey_statistics_helpers.R
@@ -242,7 +242,7 @@ factor_stat_reshape <- function(stat, peel, var_names, peel_levels) {
     stat_name <- names(stat)[iii]
     stat_df <- stat[[iii]]
     if (stat_name == "grps") {
-      stat_df <- dplyr::tbl_df(stat_df)
+      stat_df <- tibble::as_tibble(stat_df)
       stat_df[rep(seq_len(nrow(stat_df)), length(var_names)), ]
     } else if(stat_name == "ci") {
       out <- utils::stack(stat_df)

--- a/R/tbl-svy.r
+++ b/R/tbl-svy.r
@@ -100,17 +100,17 @@ as_tbl_svy <- function(x, var_names = list()) {
     # Convert to tbls if not already (expect them to be one of data.frame or tbl_df)
     # data.frames will be converted, others should inherit "tbl".
     if (!inherits(x$phase1$full$variables, "tbl")) {
-      x$phase1$full$variables <- dplyr::tbl_df(x$phase1$full$variables)
+      x$phase1$full$variables <- tibble::as_tibble(x$phase1$full$variables)
     }
     if (!inherits(x$phase1$sample$variables, "tbl")) {
-      x$phase1$sample$variables <- dplyr::tbl_df(x$phase1$sample$variables)
+      x$phase1$sample$variables <- tibble::as_tibble(x$phase1$sample$variables)
     }
 
     # To make twophase behave similarly to the other survey objects, add sample
     # variables from phase1 to the first level of the object.
     x$variables <- x$phase1$sample$variables
   } else if (!inherits(x$variables, "tbl")) {
-      x$variables <- dplyr::tbl_df(x$variables)
+      x$variables <- tibble::as_tibble(x$variables)
   }
 
   survey_vars(x) <- strip_varlist_formula(var_names)

--- a/R/utils.r
+++ b/R/utils.r
@@ -21,7 +21,7 @@ NULL
 # the logic is a little complicated:
 # 1) If `vars` evaluates to a single column name, it will use the column
 # 2) If it is not a column name and it evaluates to 0 or 1 then return ~0/~1
-# 3) If it is anything else, use dplyr::select_vars to find columns
+# 3) If it is anything else, use tidyselect::vars_select to find columns
 srvyr_select_vars <- function(vars, data, check_ids = FALSE) {
   vars <- vars
   var_names <- dplyr::tbl_vars(data)
@@ -33,7 +33,7 @@ srvyr_select_vars <- function(vars, data, check_ids = FALSE) {
   }
   if (is.null(rlang::f_rhs(vars))) return(NULL)
 
-  out_vars <- dplyr::select_vars(var_names, !!vars)
+  out_vars <- tidyselect::vars_select(var_names, !!vars)
   survey::make.formula(out_vars)
 }
 

--- a/tests/testthat/test_as_survey_design.r
+++ b/tests/testthat/test_as_survey_design.r
@@ -5,7 +5,7 @@ df <- data.frame(id = 1:5, strata = c(2, 2, 3, 3, 3), x = 11:15)
            expect_equal(df %>%
                           as_survey_design(ids = id, strata = strata),
                         df %>%
-                          dplyr::tbl_df() %>%
+                          tibble::as_tibble() %>%
                           as_survey_design(ids = id, strata = strata)))
 
 

--- a/tests/testthat/test_as_survey_twophase.r
+++ b/tests/testthat/test_as_survey_twophase.r
@@ -28,7 +28,7 @@ survey_results <- list(
 ) %>% dplyr::bind_cols() %>%
   setNames(c("mean", "mean_se", "total", "total_se", "median", "median_se",
              "var", "var_se", "ratio", "ratio_se")) %>%
-  dplyr::tbl_df()
+  tibble::as_tibble()
 
 srvyr_results <- d2pbc_srvyr %>%
   summarize(mean = survey_mean(bili),
@@ -60,7 +60,7 @@ survey_results <- list(
   setNames(c("sex", "mean", "mean_se", "sex2", "total", "total_se",
              "sex3", "median", "median_se")) %>%
   select(-sex2, -sex3) %>%
-  dplyr::tbl_df()
+  tibble::as_tibble()
 
 attr(survey_results, "svyby") <- NULL
 attr(survey_results, "call") <- NULL

--- a/tests/testthat/test_survey_mean_factor.r
+++ b/tests/testthat/test_survey_mean_factor.r
@@ -92,7 +92,7 @@ test_that("survey_* preserves character when calculating a statistic (multi grps
 # confidence intervals
 out_survey_mn <- svymean(~awards, dstrata)
 out_survey_tot <- svytotal(~awards, dstrata)
-out_survey <- dplyr::data_frame(
+out_survey <- tibble::tibble(
   awards = factor(c("No", "Yes")),
   pct = as.numeric(out_survey_mn),
   pct_low = as.numeric(confint(out_survey_mn, df = degf(dstrata))[, 1]),

--- a/tests/testthat/test_survey_package.r
+++ b/tests/testthat/test_survey_package.r
@@ -17,7 +17,7 @@ survey_chisq <- suppressWarnings(svychisq(~sch.wide + stype, dclus1_survey)[["p.
 
 ## survey with a tibble
 dclus1_survey_tibble <- svydesign(id = ~dnum, weights = ~pw, fpc = ~fpc,
-                                  data = dplyr::as_data_frame(apiclus1))
+                                  data = tibble::as_tibble(apiclus1))
 srvyr_chisq <- suppressWarnings(svychisq(~sch.wide + stype, dclus1_srvyr)[["p.value"]])
 
 

--- a/tests/testthat/test_survey_proportion.R
+++ b/tests/testthat/test_survey_proportion.R
@@ -29,7 +29,7 @@ out_srvyr <- dstrata %>%
 
 out_survey <- svyby(~awards == "Yes", ~stype, dstrata, svyciprop,
                     vartype = "ci", method = "likelihood")
-out_survey <- dplyr::tbl_df(data.frame(out_survey))
+out_survey <- tibble::as_tibble(data.frame(out_survey))
 names(out_survey) <- c("stype", "x", "x_low", "x_upp")
 
 test_that("grouped proportion works correctly",

--- a/tests/testthat/test_survey_statistics.r
+++ b/tests/testthat/test_survey_statistics.r
@@ -251,7 +251,7 @@ temp_survey <- svyby(~api99, ~stype, dstrata, svyratio, deff = TRUE,
                      vartype = c("se", "ci"), denominator = ~api00)
 out_survey <- temp_survey %>%
   data.frame() %>%
-  dplyr::tbl_df() %>%
+  tibble::as_tibble() %>%
   rename(survey_ratio = api99.api00, survey_ratio_low = ci_l,
          survey_ratio_upp = ci_u, survey_ratio_deff = `DEff`) %>%
   select(-se.api99.api00)
@@ -282,7 +282,7 @@ temp_survey <- suppressWarnings(
 
 out_survey <- temp_survey %>%
   data.frame() %>%
-  dplyr::tbl_df() %>%
+  tibble::as_tibble() %>%
   rename(survey = api99, survey_low = ci_l, survey_upp = ci_u) %>%
   select(-se)
 

--- a/tests/testthat/test_survey_statistics_basic.r
+++ b/tests/testthat/test_survey_statistics_basic.r
@@ -57,7 +57,7 @@ test_that("df works for ungrouped survey total",
 temp_survey <- svyby(~api99, ~stype, dstrata, svymean, deff = TRUE, vartype = c("se", "ci"))
 out_survey <- temp_survey %>%
   data.frame() %>%
-  dplyr::tbl_df() %>%
+  tibble::as_tibble() %>%
   rename(survey_mean = api99, survey_mean_se = se, survey_mean_low = ci_l,
          survey_mean_upp = ci_u, survey_mean_deff = `DEff.api99`)
 
@@ -122,7 +122,7 @@ test_that("survey_total works for ungrouped surveys - with vartype = NULL",
 temp_survey <- svyby(~api99, ~stype, dstrata, svytotal, deff = TRUE, vartype = c("se", "ci"))
 out_survey <- temp_survey %>%
   data.frame() %>%
-  dplyr::tbl_df() %>%
+  tibble::as_tibble() %>%
   rename(survey_total = api99, survey_total_se = se,
          survey_total_low = ci_l, survey_total_upp = ci_u,
          survey_total_deff = `DEff.api99`)


### PR DESCRIPTION
Replace instances of deprecated functions from dplyr.

Specifically, the following replacements have been made:

- `dplyr::data_frame()` -> `tibble::tibble()`
- `dplyr::as_data_frame()` -> `tibble::as_tibble()`
- `dplyr::tbl_df()` -> `tibble::as_tibble()`
- `dplyr::select_vars()` -> `tidyselect::vars_select()`

Because of the use of `tidyselect::vars_select()`, the `tidyselect` package has been added to `Imports`