### PR TITLE
Update quasiquotation syntax inside `unweighted`.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # srvyr (development version)
+* Small update to quasiquotation syntax inside `unweighted` to improve consistency with recent rlang updates (#54).
 
 # srvyr 0.3.5
 * New functions survey_var and survey_sd to calculate population variance and

--- a/R/survey_statistics.r
+++ b/R/survey_statistics.r
@@ -696,7 +696,7 @@ survey_sd <- function(
 unweighted <- function(x, .svy = current_svy(), ...) {
   dots <- rlang::enquo(x)
 
-  out <- summarize(.svy[["variables"]], !!!dots)
+  out <- summarize(.svy[["variables"]], !!dots)
   names(out)[length(names(out))] <- ""
   out
 }


### PR DESCRIPTION
This would switch to "!!" instead of "!!!" since only one variable name or expression is meant to be used with the `x` argument to `unweighted`. This avoids the warning message thrown when using `!!!enquos()` instead of `!!enquo()`.

This would resolve the warning message displayed in #54  and would avoid potential issues if the tidyverse team eventually hard-deprecates the use of `!!!enquo()`.