### PR TITLE
Add tests for `filter_if`

### DIFF
--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -412,4 +412,121 @@ source("utilities.R")
           )
         })
 
+# filter_if ----
+
+      is_yes_no_factor <- function(x) {
+        is.factor(x) && any(c("Yes", "No") %in% levels(x))
+      }
+
+      test_that(
+        "filter_if works with all_vars() predicate", {
+          # Stratified design
+          expect_equal(
+            # Survey design object
+            object = stratified_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apistrat %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Cluster design
+          expect_equal(
+            # Survey design object
+            object = cluster_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apiclus1 %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Calibration weighted design
+          ## First check that the correct number of rows are retained
+          expect_equal(
+            object =  raked_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow(),
+            expected = subset(raked_design,
+                              sch.wide == "Yes" & comp.imp == "Yes" & both == "Yes" & awards == "Yes" & yr.rnd == "Yes") %>%
+              nrow()
+          )
+          ## Next check that calculation results match behavior of survey package
+          expect_equal(
+            object = raked_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              summarize(api_ratio = survey_ratio(api00, api99, vartype = NULL)) %>%
+              dplyr::pull("api_ratio"),
+            expected = svyratio(
+              numerator = ~ api00, denominator = ~ api99,
+              design = subset(raked_design,
+                              sch.wide == "Yes" & comp.imp == "Yes" & both == "Yes" & awards == "Yes" & yr.rnd == "Yes")
+            )[['ratio']][1]
+          )
+        })
+
+      test_that(
+        "filter_if works with any_vars() predicate", {
+          # Stratified design
+          expect_equal(
+            # Survey design object
+            object = stratified_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apistrat %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Cluster design
+          expect_equal(
+            # Survey design object
+            object = cluster_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apiclus1 %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Calibration weighted design
+          ## First check that the correct number of rows are retained
+          expect_equal(
+            object =  raked_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow(),
+            expected = subset(raked_design,
+                              sch.wide == "Yes" | comp.imp == "Yes" | both == "Yes" | awards == "Yes" | yr.rnd == "Yes") %>%
+              nrow()
+          )
+          ## Next check that calculation results match behavior of survey package
+          expect_equal(
+            object = raked_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              summarize(api_ratio = survey_ratio(api00, api99, vartype = NULL)) %>%
+              dplyr::pull("api_ratio"),
+            expected = svyratio(
+              numerator = ~ api00, denominator = ~ api99,
+              design = subset(raked_design,
+                              sch.wide == "Yes" | comp.imp == "Yes" | both == "Yes" | awards == "Yes" | yr.rnd == "Yes")
+            )[['ratio']][1]
+          )
+        })
 


### PR DESCRIPTION
This updates the set of tests for `filter` variants by adding two tests for `filter_if`, one using the `all_vars()` predicate and the other using the `any_vars()` predicate. Both tests include checks for three types of survey designs: stratified, clustered, and calibration-weighted (which has special filtering behavior because of the unique way that the survey package subsets data from calibration-weighted designs).

At the moment, these tests fail because `filter_if()` seems to generally throw an error with the message ``Error: `.predicate` has no matching columns``, as in the following example.

``` r
library(survey)
library(dplyr)
library(srvyr)

# Create simple stratified survey design object

  data (api)

  stratified_design <- apistrat %>%
    as_survey_design(strata = stype, weights = pw)

# Create helper function to check if a vector is a factor with 'Yes'/'No' levels
  is_yes_no_factor <- function(x) {
    is.factor(x) && any(c("Yes", "No") %in% levels(x))
  }

# Try to use filter_if with a survey design object
  stratified_design %>%
    filter_if(is_yes_no_factor,
              all_vars(. == "Yes"))
#> Error: `.predicate` has no matching columns

# Use filter_if with the underlying regular data frame
  apistrat %>%
    filter_if(is_yes_no_factor,
              all_vars(. == "Yes"))
#>               cds stype            name                        sname snum
#> 1  19647336016018     E Belvedere Eleme         Belvedere Elementary 1622
#> 2  37683956098487     E Nicoloff (Georg Nicoloff (George) Elementary 4637
#> 3  19647336016620     E Corona Avenue E     Corona Avenue Elementary 1678
#> 4  36678506036651     E Kelley Elementa            Kelley Elementary 4100
#> 5  30666706111298     E Walker Elementa            Walker Elementary 3154
#> 6  30666706030241     E Edison Elementa            Edison Elementary 3122
#> 7  33672156032726     E Monroe Elementa            Monroe Elementary 3525
#> 8  36676866035653     E Lewis (Mary B.)   Lewis (Mary B.) Elementary 3975
#> 9  36677106111173     E Hemlock Element           Hemlock Elementary 4026
#> 10 10739996007371     E Sun Empire Elem        Sun Empire Elementary  753
#> 11 33669776031553     E Myra Linn Eleme         Myra Linn Elementary 3351
#> 12 37680986066997     E Miller Elementa            Miller Elementary 4352
#> 13 19648576106793     E Joshua Hills El      Joshua Hills Elementary 2192
#> 14 19647336016109     E Broad Avenue El      Broad Avenue Elementary 1631
#> 15 37684526059810     M Washington Midd            Washington Middle 4649
#> 16 33751766032056     E Machado Element           Machado Elementary 3563
#>                    dname dnum          cname cnum flag pcttest api00 api99
#> 1    Los Angeles Unified  401    Los Angeles   18   NA     100   516   476
#> 2   South Bay Union Elem  702      San Diego   36   NA     100   592   508
#> 3    Los Angeles Unified  401    Los Angeles   18   NA     100   497   440
#> 4         Rialto Unified  590 San Bernardino   35   NA     100   509   470
#> 5      Santa Ana Unified  653         Orange   29   NA     100   539   500
#> 6      Santa Ana Unified  653         Orange   29   NA     100   503   442
#> 7      Riverside Unified  605      Riverside   32   NA      99   632   568
#> 8   Colton Joint Unified  148 San Bernardino   35   NA      99   553   499
#> 9        Fontana Unified  238 San Bernardino   35   NA      99   588   533
#> 10        Kerman Unified  333         Fresno    9   NA     100   669   536
#> 11        Alvord Unified   19      Riverside   32   NA      97   578   535
#> 12  Escondido Union Elem  216      San Diego   36   NA     100   777   750
#> 13   Palmdale Elementary  532    Los Angeles   18   NA      99   723   671
#> 14   Los Angeles Unified  401    Los Angeles   18   NA      98   609   541
#> 15         Vista Unified  780      San Diego   36   NA      98   606   575
#> 16 Lake Elsinore Unified  358      Riverside   32   NA      99   568   504
#>    target growth sch.wide comp.imp both awards meals ell yr.rnd mobility
#> 1      16     40      Yes      Yes  Yes    Yes    98  77    Yes       26
#> 2      15     84      Yes      Yes  Yes    Yes    75  58    Yes       23
#> 3      18     57      Yes      Yes  Yes    Yes    95  66    Yes       18
#> 4      17     39      Yes      Yes  Yes    Yes    75  32    Yes       32
#> 5      15     39      Yes      Yes  Yes    Yes    92  80    Yes       27
#> 6      18     61      Yes      Yes  Yes    Yes    95  73    Yes       17
#> 7      12     64      Yes      Yes  Yes    Yes    51  18    Yes       19
#> 8      15     54      Yes      Yes  Yes    Yes    80  33    Yes       25
#> 9      13     55      Yes      Yes  Yes    Yes    54  24    Yes       17
#> 10     13    133      Yes      Yes  Yes    Yes   100  50    Yes       17
#> 11     13     43      Yes      Yes  Yes    Yes    69  41    Yes       38
#> 12      3     27      Yes      Yes  Yes    Yes    25   8    Yes       13
#> 13      6     52      Yes      Yes  Yes    Yes    46  12    Yes       99
#> 14     13     68      Yes      Yes  Yes    Yes    82  33    Yes       41
#> 15     11     31      Yes      Yes  Yes    Yes    57  15    Yes       15
#> 16     15     64      Yes      Yes  Yes    Yes    69  34    Yes       25
#>    acs.k3 acs.46 acs.core pct.resp not.hsg hsg some.col col.grad grad.sch
#> 1      19     28       NA        0       0   0        0        0        0
#> 2      20     32       NA        0       0   0        0        0        0
#> 3      19     30       NA       71      45  36       11        8        0
#> 4      19     34       NA        5      28  55       10        7        0
#> 5      20     30       NA       62      56  27       12        4        1
#> 6      22     31       NA       62      51  30       16        3        0
#> 7      19     31       NA       85      21  27       33       12        7
#> 8      20     30       NA       89      35  47       13        5        1
#> 9      19     30       NA        6      28  36       20       16        0
#> 10     18     27       NA       95      47  25       17        8        4
#> 11     20     31       NA       96      34  36       22        6        2
#> 12     20     31       NA        2       0  20       40       10       30
#> 13     18     30       NA       73      10  25       37       18       10
#> 14     19     27       NA       88      15  46       22       15        2
#> 15     NA     30       31       89      27  22       28       18        6
#> 16     20     28       NA       99      22  37       25       11        4
#>    avg.ed full emer enroll api.stu    pw  fpc
#> 1    1.67   57   40    841     631 44.21 4421
#> 2    2.17   91   14    763     652 44.21 4421
#> 3    1.82   67   33   1112     931 44.21 4421
#> 4    1.97   78   23    522     437 44.21 4421
#> 5    1.68   80   17    603     532 44.21 4421
#> 6    1.73   80   20    643     567 44.21 4421
#> 7    2.57   91   15    555     484 44.21 4421
#> 8    1.89   67   28    571     436 44.21 4421
#> 9    2.24   78   16    441     383 44.21 4421
#> 10   1.96   82   18    587     478 44.21 4421
#> 11   2.07   81   16    492     376 44.21 4421
#> 12   3.50  100    3    437     381 44.21 4421
#> 13   2.93   73   24    770     645 44.21 4421
#> 14   2.44   84   12    678     403 44.21 4421
#> 15   2.53   96    1   1524    1254 20.36 1018
#> 16   2.38   83   17    601     457 44.21 4421
```

<sup>Created on 2019-11-11 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>
