### PR TITLE
Update `unweighted()` to ignore filtered-out rows in calibrated or PPS designs

### DIFF
--- a/R/survey_statistics.r
+++ b/R/survey_statistics.r
@@ -722,7 +722,13 @@ unweighted <- function(x, .svy = current_svy(), ...) {
   # survey statistics
   dots <- rlang::quo_set_env(dots, rlang::env_parent(n = 2))
 
-  out <- summarize(.svy[["variables"]], !!dots)
+  if (is.calibrated(.svy) | is.pps(.svy)) {
+    excluded_rows <- is.infinite(.svy[['prob']])
+    out <- summarize(.svy[["variables"]][!excluded_rows,], !!dots)
+  } else {
+    out <- summarize(.svy[["variables"]], !!dots)
+  }
+
   names(out)[length(names(out))] <- ""
   out
 }

--- a/tests/testthat/test_survey_statistics.r
+++ b/tests/testthat/test_survey_statistics.r
@@ -686,6 +686,48 @@ test_that(
   }
 )
 
+test_that(
+  "unweighted works with filtered data in calibrated or PPS designs", {
+    data(api, package = "survey")
+    dclus1 <- as_survey_design(apiclus1, id = dnum, weights = pw, fpc = fpc)
+
+    pop.types <- data.frame(stype=c("E","H","M"), Freq=c(4421,755,1018))
+    pop.schwide <- data.frame(sch.wide=c("No","Yes"), Freq=c(1072,5122))
+
+    raked_design <- rake(dclus1,
+                         sample.margins = list(~stype,~sch.wide),
+                         population.margins = list(pop.types, pop.schwide))
+
+    out_calib <- raked_design %>%
+      filter(sch.wide == "Yes") %>%
+      group_by(stype) %>%
+      summarize(sample_size = unweighted(n()))
+
+    out_noncalib <- dclus1 %>%
+      filter(sch.wide == "Yes") %>%
+      group_by(stype) %>%
+      summarize(sample_size = unweighted(n()))
+
+    expect_equal(out_calib[['sample_size']],
+                 out_noncalib[['sample_size']])
+
+    data(election, package = "survey")
+
+    non_pps_design <- as_survey_design(election_pps, id = 1)
+    pps_design <- as_survey_design(election_pps, id = 1, fpc = p, pps = "brewer")
+
+    out_nonpps <- non_pps_design %>%
+      filter(County == "Los Angeles") %>%
+      summarize(n_rows = unweighted(n()))
+
+    out_pps <- non_pps_design %>%
+      filter(County == "Los Angeles") %>%
+      summarize(n_rows = unweighted(n()))
+
+    expect_equal(out_pps[['n_rows']],
+                 out_nonpps[['n_rows']])
+  }
+)
 
 test_that(
   "Can groupby before or after a filter (#59)", {


### PR DESCRIPTION
This updates the `unweighted()` function so that it ignores 'filtered-out' rows in calibrated or PPS designs and adds a corresponding test. This addresses #82 and should help avoid the kind of confusion experienced in #51. It works by noting that, for calibrated or PPS designs, filtered rows aren't removed from `.svy[['variables']]`; instead, those rows have values of `Inf` in `.svy[['prob']]` (this comes from `` survey:::`[.survey.design2` `` and the like).