### PR TITLE
Inside `survey_stat_factor()`, "reverse" conversion of peel variable back from numeric to character

### DIFF
--- a/R/survey_statistics.r
+++ b/R/survey_statistics.r
@@ -741,7 +741,12 @@ survey_stat_factor <- function(.svy, func, na.rm, vartype, level, deff, df) {
 
   if (is.numeric(.svy$variables[[peel_name]])) {
     warning("Coercing ", peel_name, " to character.", call. = FALSE)
-    .svy$variables[[peel_name]] <- as.character(.svy$variables[[peel_name]])
+    peel_var_coerced_to_char <- TRUE
+    peel_var_orig_type <- typeof(.svy$variables[[peel_name]])
+    .svy$variables[[peel_name]] <- format(.svy$variables[[peel_name]],
+                                          nsmall = 20, digits = 22)
+  } else {
+    peel_var_coerced_to_char <- FALSE
   }
 
   if (length(level) > 1) {
@@ -778,6 +783,11 @@ survey_stat_factor <- function(.svy, func, na.rm, vartype, level, deff, df) {
       stat, vartype, grps = "", peel = peel_name, peel_levels = peel_levels,
        peel_is_factor = peel_is_factor, df = df, deff = deff
     )
+
+    if (peel_var_coerced_to_char) {
+      out[[peel_name]] <- as(out[[peel_name]], peel_var_orig_type)
+    }
+
     out
   }
 }

--- a/tests/testthat/test_survey_count_tally.R
+++ b/tests/testthat/test_survey_count_tally.R
@@ -40,3 +40,94 @@ test_that("Parameters for survey_count/tally work", {
   expect_equal(res$n, sort(as.vector(expected$n), decreasing = TRUE))
   expect_equal(res$n_cv, as.vector(expected$cv)[rev(order(as.vector(expected$n)))])
 })
+
+test_that("survey_count/tally works with integer grouping variables", {
+  dstrata <- apistrat %>%
+    as_survey_design(strata = stype, weights = pw)
+
+  factor_survey <- dstrata %>%
+    mutate(api_diff = dplyr::case_when(api00 - api99 > 0 ~ "Increase",
+                                       api00 - api99 < 0 ~ "Decrease",
+                                       api00 == api99 ~ "Unchanged")) %>%
+    mutate(fct_api_diff = factor(api_diff, levels = c("Decrease", "Unchanged", "Increase")))
+
+  int_survey <- factor_survey %>%
+    mutate(int_api_diff = as.integer(fct_api_diff))
+
+  int_tally_out <- int_survey %>%
+    group_by(int_api_diff) %>%
+    survey_tally()
+
+  factor_tally_out <- factor_survey %>%
+    group_by(fct_api_diff) %>%
+    survey_tally()
+
+  int_count_out <- int_survey %>%
+    survey_count(int_api_diff)
+
+  factor_count_out <- factor_survey %>%
+    survey_count(fct_api_diff)
+
+  expect_equal(object = int_tally_out[['n']],
+               expected = factor_tally_out[['n']])
+  expect_equal(object = int_tally_out[['n_se']],
+               expected = factor_tally_out[['n_se']])
+  expect_equal(object = int_count_out[['n']],
+               expected = factor_count_out[['n']])
+  expect_equal(object = int_count_out[['n_se']],
+               expected = factor_count_out[['n_se']])
+})
+
+test_that("survey_count/tally works with numeric double grouping variables", {
+  dstrata <- apistrat %>%
+    as_survey_design(strata = stype, weights = pw) %>%
+    mutate(dbl_group_var = sample(c(48908512.23121595515890890346346,
+                                    0.298908534689384963334663431241,
+                                    89068093804986346.12141251885551),
+                                  size = nrow(apistrat),
+                                  replace = TRUE),
+           fct_group_var = as.factor(as.character(dbl_group_var)))
+
+  dbl_tally_out <- dstrata %>%
+    group_by(dbl_group_var) %>%
+    survey_tally()
+
+  factor_tally_out <- dstrata %>%
+    group_by(fct_group_var) %>%
+    survey_tally()
+
+  dbl_count_out <- dstrata %>%
+    survey_count(dbl_group_var)
+
+  factor_count_out <- dstrata %>%
+    survey_count(fct_group_var)
+
+  expect_equal(object = dbl_tally_out[['n']],
+               expected = factor_tally_out[['n']])
+  expect_equal(object = dbl_tally_out[['n_se']],
+               expected = factor_tally_out[['n_se']])
+  expect_equal(object = dbl_count_out[['n']],
+               expected = factor_count_out[['n']])
+  expect_equal(object = dbl_count_out[['n_se']],
+               expected = factor_count_out[['n_se']])
+})
+
+test_that("no noticeable precision loss of numeric grouping variable in survey_count/tally ", {
+  dstrata <- apistrat %>%
+    as_survey_design(strata = stype, weights = pw) %>%
+    mutate(numeric_group_var = sample(c(48908512.23121595515890890346346,
+                                        0.298908534689384963334663431241,
+                                        89068093804986346.12141251885551),
+                                      size = nrow(apistrat),
+                                      replace = TRUE),
+           char_group_var = as.character(numeric_group_var))
+
+  numeric_tally_out <- dstrata %>%
+    group_by(numeric_group_var) %>%
+    survey_tally()
+
+  expect_equal(object = sort(unique(numeric_tally_out[['numeric_group_var']])),
+               expected = sort(unique(dstrata$variables[['numeric_group_var']])),
+               tolerance = .Machine$double.eps)
+
+})


### PR DESCRIPTION
This is one way to fix #78 and #74.

Inside `survey_stat_factor()`, after `.svy$variables[[peel_var]]` is converted to a character vector, the corresponding column in the output `out[[peel_var]]` is converted back to the original type. In conducting the conversion from numeric to character, the `format()` function is used to maintain the maximum possible precision when converting from numeric to character.

My only qualm with this approach is that it is possible that some desired level of numeric precision is lost when converting from numeric to character, and perhaps there is a similarly simple solution which would avoid this issue of precision.