### PR TITLE
Add tests for `filter_if()`

### DIFF
--- a/tests/testthat/test_filter.R
+++ b/tests/testthat/test_filter.R
@@ -412,4 +412,120 @@ source("utilities.R")
           )
         })
 
+# filter_if ----
 
+      is_yes_no_factor <- function(x) {
+        is.factor(x) && any(c("Yes", "No") %in% levels(x))
+      }
+
+      test_that(
+        "filter_if works with all_vars() predicate", {
+          # Stratified design
+          expect_equal(
+            # Survey design object
+            object = stratified_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apistrat %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Cluster design
+          expect_equal(
+            # Survey design object
+            object = cluster_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apiclus1 %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Calibration weighted design
+          ## First check that the correct number of rows are retained
+          expect_equal(
+            object =  raked_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              nrow(),
+            expected = subset(raked_design,
+                              sch.wide == "Yes" & comp.imp == "Yes" & both == "Yes" & awards == "Yes" & yr.rnd == "Yes") %>%
+              nrow()
+          )
+          ## Next check that calculation results match behavior of survey package
+          expect_equal(
+            object = raked_design %>%
+              filter_if(is_yes_no_factor,
+                        all_vars(. == "Yes")) %>%
+              summarize(api_ratio = survey_ratio(api00, api99, vartype = NULL)) %>%
+              dplyr::pull("api_ratio"),
+            expected = svyratio(
+              numerator = ~ api00, denominator = ~ api99,
+              design = subset(raked_design,
+                              sch.wide == "Yes" & comp.imp == "Yes" & both == "Yes" & awards == "Yes" & yr.rnd == "Yes")
+            )[['ratio']][1]
+          )
+        })
+
+      test_that(
+        "filter_if works with any_vars() predicate", {
+          # Stratified design
+          expect_equal(
+            # Survey design object
+            object = stratified_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apistrat %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Cluster design
+          expect_equal(
+            # Survey design object
+            object = cluster_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow(),
+            # Underlying data frame (not a survey design object)
+            expected = apiclus1 %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow()
+          )
+
+          # Calibration weighted design
+          ## First check that the correct number of rows are retained
+          expect_equal(
+            object =  raked_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              nrow(),
+            expected = subset(raked_design,
+                              sch.wide == "Yes" | comp.imp == "Yes" | both == "Yes" | awards == "Yes" | yr.rnd == "Yes") %>%
+              nrow()
+          )
+          ## Next check that calculation results match behavior of survey package
+          expect_equal(
+            object = raked_design %>%
+              filter_if(is_yes_no_factor,
+                        any_vars(. == "Yes")) %>%
+              summarize(api_ratio = survey_ratio(api00, api99, vartype = NULL)) %>%
+              dplyr::pull("api_ratio"),
+            expected = svyratio(
+              numerator = ~ api00, denominator = ~ api99,
+              design = subset(raked_design,
+                              sch.wide == "Yes" | comp.imp == "Yes" | both == "Yes" | awards == "Yes" | yr.rnd == "Yes")
+            )[['ratio']][1]
+          )
+        })


### PR DESCRIPTION
This updates the set of tests for `filter` variants by adding two tests for `filter_if`, one using the `all_vars()` predicate and the other using the `any_vars()` predicate. Both tests include checks for three types of survey designs: stratified, clustered, and calibration-weighted (which has special filtering behavior because of the unique way that the survey package subsets data from calibration-weighted designs).

Since dplyr is classifying `filter_if/at/all` as "superseded" rather than deprecated, it seems like it's worth having these tests here. Perhaps down the line support for the `_if/at/all` variants in `srvyr` might go away as `across()` becomes more established in the tidyverse.
