### PR TITLE
Helper functions for factors distinguish between ordered and unordered

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,5 @@
 # srvyr (development version)
+* Fix to ensure that ordered factors can be used as grouping variables or as inputs to `survey_count` and `survey_tally` (#92).
 
 # srvyr 0.3.10
 * Another fix for upcoming dplyr

--- a/R/survey_statistics.r
+++ b/R/survey_statistics.r
@@ -752,8 +752,10 @@ survey_stat_factor <- function(.svy, func, na.rm, vartype, level, deff, df) {
   peel_is_factor <- is.factor(.svy[["variables"]][[peel_name]])
   if (peel_is_factor) {
     peel_levels <- levels(.svy[["variables"]][[peel_name]])
+    peel_is_ordered <- is.ordered(.svy[["variables"]][[peel_name]])
   } else {
     peel_levels <- sort(unique(.svy[["variables"]][[peel_name]]))
+    peel_is_ordered <- FALSE
   }
   if (length(grps_names) > 0) {
     stat <- survey::svyby(survey::make.formula(peel_name),
@@ -766,7 +768,7 @@ survey_stat_factor <- function(.svy, func, na.rm, vartype, level, deff, df) {
 
     out <- get_var_est_factor(
       stat, vartype, grps = grps_names, peel = peel_name,
-      peel_is_factor = peel_is_factor, peel_levels = peel_levels,
+      peel_is_factor = peel_is_factor, peel_levels = peel_levels, peel_is_ordered = peel_is_ordered,
       level = level, df = df, deff = deff
     )
 
@@ -775,7 +777,7 @@ survey_stat_factor <- function(.svy, func, na.rm, vartype, level, deff, df) {
     stat <- func(survey::make.formula(peel_name), .svy, na.rm = na.rm, deff = deff)
 
     out <- get_var_est_factor(
-      stat, vartype, grps = "", peel = peel_name, peel_levels = peel_levels,
+      stat, vartype, grps = "", peel = peel_name, peel_levels = peel_levels, peel_is_ordered = peel_is_ordered,
        peel_is_factor = peel_is_factor, df = df, deff = deff
     )
     out

--- a/R/survey_statistics_helpers.R
+++ b/R/survey_statistics_helpers.R
@@ -174,7 +174,7 @@ get_var_est_quantile <- function(stat, vartype, q, grps = "", level = 0.95, df =
 # Again a fair amount of overlap with the other get_var_ests, but handles the way
 # factors are peeled off
 get_var_est_factor <- function(
-  stat, vartype, grps, peel, peel_levels, peel_is_factor, level = 0.95, df = Inf, deff = FALSE
+  stat, vartype, grps, peel, peel_levels, peel_is_factor, peel_is_ordered, level = 0.95, df = Inf, deff = FALSE
 ) {
   var_names <- if (length(grps) > 0) peel_levels else ""
   out_width <- length(var_names)
@@ -234,11 +234,11 @@ get_var_est_factor <- function(
     names(out) <- names_out
   }
   if (!peel_is_factor) peel_levels <- NULL
-  out <- factor_stat_reshape(out, peel, var_names, peel_levels)
+  out <- factor_stat_reshape(out, peel, var_names, peel_levels, peel_is_ordered)
   out
 }
 
-factor_stat_reshape <- function(stat, peel, var_names, peel_levels) {
+factor_stat_reshape <- function(stat, peel, var_names, peel_levels, peel_is_ordered) {
   out <- lapply(seq_along(stat), function(iii) {
     stat_name <- names(stat)[iii]
     stat_df <- stat[[iii]]
@@ -268,7 +268,7 @@ factor_stat_reshape <- function(stat, peel, var_names, peel_levels) {
   # peel's factor was created by stack, but is just alphabetic
   out[[peel]] <- as.character(out[[peel]])
   if (!is.null(peel_levels)) {
-    out[[peel]] <- factor(out[[peel]], peel_levels)
+    out[[peel]] <- factor(out[[peel]], peel_levels, ordered = peel_is_ordered)
   }
 
   out

--- a/tests/testthat/test_survey_mean_factor.r
+++ b/tests/testthat/test_survey_mean_factor.r
@@ -88,6 +88,18 @@ test_that("survey_* preserves character when calculating a statistic (multi grps
           expect_true(class(out_srvyr$stype2) == "character")
 )
 
+# Preserves factor's status as ordered or unordered
+
+out_srvyr <- dstrata %>%
+  mutate(stype2 = as.ordered(stype)) %>%
+  group_by(stype2) %>%
+  summarize(tot = survey_total())
+
+test_that("survey_* preserves factor's status as ordered or unordered",
+          expect_true("factor" %in% class(out_srvyr$stype2) &
+                      "ordered" %in% class(out_srvyr$stype2))
+)
+
 
 # confidence intervals
 out_survey_mn <- svymean(~awards, dstrata)


### PR DESCRIPTION
This fixes #91 by making sure that the helper functions used for factor variables respect whether the factor variable is ordered or unordered. A simple corresponding test is added.