### PR TITLE
Remove backticks from variable names before looping

### DIFF
--- a/R/cascade.r
+++ b/R/cascade.r
@@ -52,6 +52,7 @@ cascade.grouped_svy <- function(.data, ..., .dots, .fill = NA) {
   dots <- rlang::quos(...)
 
   groups <- as.character(groups(.data))
+  groups <- gsub("^\`|\`$", "", groups)
   group_cascade <- lapply(rev(seq_along(groups)), function(x) groups[seq_len(x)])
   group_cascade[length(group_cascade) + 1] <- ""
 

--- a/R/cascade.r
+++ b/R/cascade.r
@@ -51,8 +51,7 @@ cascade.tbl_svy <- function(.data, ..., .fill = NA) {
 cascade.grouped_svy <- function(.data, ..., .dots, .fill = NA) {
   dots <- rlang::quos(...)
 
-  groups <- as.character(groups(.data))
-  groups <- gsub("^\`|\`$", "", groups)
+  groups <- group_vars(.data)
   group_cascade <- lapply(rev(seq_along(groups)), function(x) groups[seq_len(x)])
   group_cascade[length(group_cascade) + 1] <- ""
 


### PR DESCRIPTION
This addresses issue #131 by removing backticks before running through groups on cascade.

``` r
devtools::load_all(".")
```

    ## i Loading srvyr

``` r
library(survey)
```

    ## Loading required package: grid

    ## Loading required package: Matrix

    ## Loading required package: survival

    ## 
    ## Attaching package: 'survey'

    ## The following object is masked from 'package:graphics':
    ## 
    ##     dotchart

``` r
data(api)


dstrata <- apistrat %>%
  as_survey_design(strata = stype, weights = pw)

dstrata %>%
  group_by(stype) %>%
  cascade(
    api99_mn = survey_mean(api99)
  )
```

    ## # A tibble: 4 x 3
    ##   stype api99_mn api99_mn_se
    ##   <fct>    <dbl>       <dbl>
    ## 1 E         636.        13.3
    ## 2 H         617.        15.8
    ## 3 M         610.        16.8
    ## 4 <NA>      629.        10.1

``` r
dstrata %>%
  mutate(`1234`=stype) %>% #make a name in backticks
  group_by(`1234`) %>%
  cascade(
    api99_mn = survey_mean(api99)
  )
```

    ## # A tibble: 4 x 3
    ##   `1234` api99_mn api99_mn_se
    ##   <fct>     <dbl>       <dbl>
    ## 1 E          636.        13.3
    ## 2 H          617.        15.8
    ## 3 M          610.        16.8
    ## 4 <NA>       629.        10.1


