### PR TITLE
Update codecov badge with `usethis::use_coverage(type='codecov')`

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,4 @@
 ^CODE_OF_CONDUCT\.md$
 ^revdep$
 ^\.github$
+^codecov\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,8 @@ Suggests:
     pander,
     RSQLite,
     survival,
-    testthat
+    testthat,
+    covr
 Encoding: UTF-8
 VignetteBuilder: knitr
 RoxygenNote: 7.1.2

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 <!-- badges: start -->
 [![CRAN_Status_Badge](http://www.r-pkg.org/badges/version/srvyr)](https://CRAN.R-project.org/package=srvyr)
 [![R build status](https://github.com/gergness/srvyr/workflows/R-CMD-check/badge.svg)](https://github.com/gergness/srvyr/actions)
-[![codecov](https://app.codecov.io/gh/gergness/srvyr/branch/main/graph/badge.svg?token=q4DvfEj5Jj)](https://app.codecov.io/gh/gergness/srvyr)
+[![Codecov test coverage](https://codecov.io/gh/gergness/srvyr/branch/main/graph/badge.svg)](https://app.codecov.io/gh/gergness/srvyr?branch=main)
 [![Documentation via pkgdown](tools/pkgdownshield.svg)](http://gdfe.co/srvyr/)
 <!-- badges: end -->
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 [![CRAN\_Status\_Badge](http://www.r-pkg.org/badges/version/srvyr)](https://CRAN.R-project.org/package=srvyr)
 [![R build
 status](https://github.com/gergness/srvyr/workflows/R-CMD-check/badge.svg)](https://github.com/gergness/srvyr/actions)
-[![codecov](https://app.codecov.io/gh/gergness/srvyr/branch/main/graph/badge.svg?token=q4DvfEj5Jj)](https://app.codecov.io/gh/gergness/srvyr)
+[![Codecov test
+coverage](https://codecov.io/gh/gergness/srvyr/branch/main/graph/badge.svg)](https://app.codecov.io/gh/gergness/srvyr?branch=main)
 [![Documentation via
 pkgdown](tools/pkgdownshield.svg)](http://gdfe.co/srvyr/)
 <!-- badges: end -->

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+comment: false
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true


### PR DESCRIPTION
The codecov badge on the README is broken, and I think it's because there have been changes to the 'codecov' API.

![image](https://user-images.githubusercontent.com/19809917/217413510-01143e0e-5f80-4cd8-935d-7845409b06f0.png)

This PR updates the codecov badge by simply calling `usethis::use_coverage(type = "codecov")`. Here's what I see on the README after this update:

![image](https://user-images.githubusercontent.com/19809917/217413721-0c0c7a1e-5608-4f66-8948-d3a7a532191e.png)
