### PR TITLE
Documented how to get `na.rm = TRUE` behavior for proportions

### DIFF
--- a/R/survey_statistics.r
+++ b/R/survey_statistics.r
@@ -13,7 +13,8 @@
 #' allows for "unpeeling" multiple variables at once.
 #'
 #' @param x A variable or expression, or empty
-#' @param na.rm A logical value to indicate whether missing values should be dropped
+#' @param na.rm A logical value to indicate whether missing values should be dropped.
+#' See the section "Missing Values" later in this help page.
 #' @param vartype Report variability as one or more of: standard error ("se", default),
 #'                confidence interval ("ci"), variance ("var") or coefficient of variation
 #'                ("cv").
@@ -30,6 +31,16 @@
 #'           but Inf is the usual survey package's default (except in
 #'           \code{\link[survey]{svyciprop}}.
 #' @param ... Ignored
+#' @section Missing Values:
+#' When calculating proportions for a grouping variable \code{x}, \code{NA} values
+#' will affect the estimated proportions unless they are first removed by calling
+#' \code{filter(!is.na(x))}.
+#'
+#' When calculating means for a numeric variable, equivalent results are obtained
+#' by calling \code{filter(!is.na(x))} or using \code{survey_mean(x, na.rm = TRUE)}.
+#' However, it is better to use \code{survey_mean(x, na.rm = TRUE)} if
+#' you are simultaneously producing summaries for other variables
+#' that might not have missing values for the same rows as \code{x}.
 #' @examples
 #' data(api, package = "survey")
 #'

--- a/man/survey_mean.Rd
+++ b/man/survey_mean.Rd
@@ -30,7 +30,8 @@ survey_prop(
 \arguments{
 \item{x}{A variable or expression, or empty}
 
-\item{na.rm}{A logical value to indicate whether missing values should be dropped}
+\item{na.rm}{A logical value to indicate whether missing values should be dropped.
+See the section "Missing Values" later in this help page.}
 
 \item{vartype}{Report variability as one or more of: standard error ("se", default),
 confidence interval ("ci"), variance ("var") or coefficient of variation
@@ -69,6 +70,19 @@ Using \code{survey_prop} is equivalent to leaving out the \code{x} argument in
 data, with the last grouping variable "unpeeled". \code{\link{interact}}
 allows for "unpeeling" multiple variables at once.
 }
+\section{Missing Values}{
+
+When calculating proportions for a grouping variable \code{x}, \code{NA} values
+will affect the estimated proportions unless they are first removed by calling
+\code{filter(!is.na(x))}.
+
+When calculating means for a numeric variable, equivalent results are obtained
+by calling \code{filter(!is.na(x))} or using \code{survey_mean(x, na.rm = TRUE)}.
+However, it is better to use \code{survey_mean(x, na.rm = TRUE)} if
+you are simultaneously producing summaries for other variables
+that might not have missing values for the same rows as \code{x}.
+}
+
 \examples{
 data(api, package = "survey")
 


### PR DESCRIPTION
A recurring point of confusion for users is how to drop missing values of a variable they want to calculate proportions for. Right now, it seems like many users think they're supposed to be able to do this by specifying `na.rm = TRUE` (#106, #146, #149, #158).

This PR updates the help page for `survey_mean()` and `survey_prop()` to clearly document how missing values are handled by `na.rm = TRUE` and to recommend what users should do specifically for proportions.