### PR TITLE
Improve printing for survey objects to respect width

### DIFF
--- a/R/survey_vars.r
+++ b/R/survey_vars.r
@@ -31,14 +31,17 @@ print.survey_vars <- function(x, all = FALSE, ...) {
   cat("Sampling variables:\n")
   lapply(seq_along(x), function(y) {
     if (!is.null(x[[y]])) {
-      if (length(x[[y]]) > 7 & !all) {
-        num_vars <- length(x[[y]])
-        print_vars <- x[[y]][1:5]
-        cat(paste0(" - ", names(x[y]), ": ", paste(print_vars, collapse = ", "),
-                   ", ... (", num_vars - 5, " more)\n"))
-      } else {
-        cat(paste0(" - ", names(x[y]), ": ", paste(x[[y]], collapse = ", "),
-                   "\n"))
+      if (!is.null(x[[y]])) {
+        fixcarriage <- function(x){
+          # remove carriage return in repweights and extra space
+          out <- gsub("\\n    ", "", x)
+          if (is.symbol(x)){
+            as.symbol(out)
+          } else{
+            out
+          }
+        }
+        cat(wrap(paste0(" - ", names(x[y]), ": ", paste(lapply(x[[y]], fixcarriage), collapse=", ")), indent=2), "\n")
       }
     }
   })

--- a/R/tbl-svy.r
+++ b/R/tbl-svy.r
@@ -48,8 +48,8 @@ print.tbl_svy <- function (x, varnames = TRUE, all_survey_vars = FALSE, ...) {
     print(survey_vars(x), all_survey_vars)
   }
   if(length(groups(x)) != 0) {
-    cat("Grouping variables: ")
-    cat(paste0(deparse_all(groups(x)), collapse = ", "))
+    cat("Grouping variables: \n")
+    cat(wrap(paste0("- ", deparse_all(groups(x)), collapse = ", "), indent=2))
     cat("\n")
   }
 
@@ -63,7 +63,8 @@ print.tbl_svy <- function (x, varnames = TRUE, all_survey_vars = FALSE, ...) {
     }
 
     var_types <- paste0(vars, " (", types, ")", collapse = ", ")
-    cat(wrap("Data variables: ", var_types), "\n", sep = "")
+    cat("Data variables: \n")
+    cat(wrap(" - ", var_types, indent = 2), "\n", sep = "")
     invisible(x)
   }
 }


### PR DESCRIPTION
This addresses #162 

It also removes some odd //n characters that are in the replicate weights. I cannot figure out where these are added in the code so I hack it to remove them before printing. There's probably a better solution.

Some examples below but no formal tests:

``` r
# devtools::install_github("https://github.com/szimmer/srvyr/tree/print-summary-width")

library(tidyverse)
library(tidycensus)
library(srvyr)
#> 
#> Attaching package: 'srvyr'
#> The following object is masked from 'package:stats':
#> 
#>     filter

pums_in <- get_pums(
  variables = c("NP", "BDSP", "HINCP"),
  state = "37",
  puma = c("01301", "01302"),
  rep_weights = "housing",
  year = 2020,
  survey = "acs5",
  variables_filter = list(SPORDER = 1, TYPEHUGQ = 1)
)
#> Getting data from the 2016-2020 5-year ACS Public Use Microdata Sample

des_acs <- pums_in %>%
  as_survey_rep(
    weights = WGTP,
    repweights = num_range("WGTP", 1:80),
    type = "JK1",
    mse = TRUE,
    scale = 4 / 80
  )

options(width=120)
des_acs
#> Call: Called via srvyr
#> Unstratified cluster jacknife (JK1) with 80 replicates and MSE variances.
#> Sampling variables:
#>   - repweights: `WGTP1 + WGTP2 + WGTP3 + WGTP4 + WGTP5 + WGTP6 + WGTP7 + WGTP8 + WGTP9 + WGTP10 + WGTP11 + WGTP12 +
#>     WGTP13 + WGTP14 + WGTP15 + WGTP16 + WGTP17 + WGTP18 + WGTP19 + WGTP20 + WGTP21 + WGTP22 + WGTP23 + WGTP24 + WGTP25
#>     + WGTP26 + WGTP27 + WGTP28 + WGTP29 + WGTP30 + WGTP31 + WGTP32 + WGTP33 + WGTP34 + WGTP35 + WGTP36 + WGTP37 +
#>     WGTP38 + WGTP39 + WGTP40 + WGTP41 + WGTP42 + WGTP43 + WGTP44 + WGTP45 + WGTP46 + WGTP47 + WGTP48 + WGTP49 + WGTP50
#>     + WGTP51 + WGTP52 + WGTP53 + WGTP54 + WGTP55 + WGTP56 + WGTP57 + WGTP58 + WGTP59 + WGTP60 + WGTP61 + WGTP62 +
#>     WGTP63 + WGTP64 + WGTP65 + WGTP66 + WGTP67 + WGTP68 + WGTP69 + WGTP70 + WGTP71 + WGTP72 + WGTP73 + WGTP74 + WGTP75
#>     + WGTP76 + WGTP77 + WGTP78 + WGTP79 + WGTP80` 
#>   - weights: WGTP 
#> Data variables: 
#>   - SERIALNO (chr), SPORDER (dbl), NP (dbl), BDSP (dbl), HINCP (dbl), PUMA (chr), ST (chr), TYPEHUGQ (chr), WGTP (dbl),
#>     PWGTP (dbl), WGTP1 (dbl), WGTP2 (dbl), WGTP3 (dbl), WGTP4 (dbl), WGTP5 (dbl), WGTP6 (dbl), WGTP7 (dbl), WGTP8
#>     (dbl), WGTP9 (dbl), WGTP10 (dbl), WGTP11 (dbl), WGTP12 (dbl), WGTP13 (dbl), WGTP14 (dbl), WGTP15 (dbl), WGTP16
#>     (dbl), WGTP17 (dbl), WGTP18 (dbl), WGTP19 (dbl), WGTP20 (dbl), WGTP21 (dbl), WGTP22 (dbl), WGTP23 (dbl), WGTP24
#>     (dbl), WGTP25 (dbl), WGTP26 (dbl), WGTP27 (dbl), WGTP28 (dbl), WGTP29 (dbl), WGTP30 (dbl), WGTP31 (dbl), WGTP32
#>     (dbl), WGTP33 (dbl), WGTP34 (dbl), WGTP35 (dbl), WGTP36 (dbl), WGTP37 (dbl), WGTP38 (dbl), WGTP39 (dbl), WGTP40
#>     (dbl), WGTP41 (dbl), WGTP42 (dbl), WGTP43 (dbl), WGTP44 (dbl), WGTP45 (dbl), WGTP46 (dbl), WGTP47 (dbl), WGTP48
#>     (dbl), WGTP49 (dbl), WGTP50 (dbl), WGTP51 (dbl), WGTP52 (dbl), WGTP53 (dbl), WGTP54 (dbl), WGTP55 (dbl), WGTP56
#>     (dbl), WGTP57 (dbl), WGTP58 (dbl), WGTP59 (dbl), WGTP60 (dbl), WGTP61 (dbl), WGTP62 (dbl), WGTP63 (dbl), WGTP64
#>     (dbl), WGTP65 (dbl), WGTP66 (dbl), WGTP67 (dbl), WGTP68 (dbl), WGTP69 (dbl), WGTP70 (dbl), WGTP71 (dbl), WGTP72
#>     (dbl), WGTP73 (dbl), WGTP74 (dbl), WGTP75 (dbl), WGTP76 (dbl), WGTP77 (dbl), WGTP78 (dbl), WGTP79 (dbl), WGTP80
#>     (dbl)
summary(des_acs)
#> Call: Called via srvyr
#> Unstratified cluster jacknife (JK1) with 80 replicates and MSE variances.
#> Sampling variables:
#>   - repweights: `WGTP1 + WGTP2 + WGTP3 + WGTP4 + WGTP5 + WGTP6 + WGTP7 + WGTP8 + WGTP9 + WGTP10 + WGTP11 + WGTP12 +
#>     WGTP13 + WGTP14 + WGTP15 + WGTP16 + WGTP17 + WGTP18 + WGTP19 + WGTP20 + WGTP21 + WGTP22 + WGTP23 + WGTP24 + WGTP25
#>     + WGTP26 + WGTP27 + WGTP28 + WGTP29 + WGTP30 + WGTP31 + WGTP32 + WGTP33 + WGTP34 + WGTP35 + WGTP36 + WGTP37 +
#>     WGTP38 + WGTP39 + WGTP40 + WGTP41 + WGTP42 + WGTP43 + WGTP44 + WGTP45 + WGTP46 + WGTP47 + WGTP48 + WGTP49 + WGTP50
#>     + WGTP51 + WGTP52 + WGTP53 + WGTP54 + WGTP55 + WGTP56 + WGTP57 + WGTP58 + WGTP59 + WGTP60 + WGTP61 + WGTP62 +
#>     WGTP63 + WGTP64 + WGTP65 + WGTP66 + WGTP67 + WGTP68 + WGTP69 + WGTP70 + WGTP71 + WGTP72 + WGTP73 + WGTP74 + WGTP75
#>     + WGTP76 + WGTP77 + WGTP78 + WGTP79 + WGTP80` 
#>   - weights: WGTP 
#> Data variables: 
#>   - SERIALNO (chr), SPORDER (dbl), NP (dbl), BDSP (dbl), HINCP (dbl), PUMA (chr), ST (chr), TYPEHUGQ (chr), WGTP (dbl),
#>     PWGTP (dbl), WGTP1 (dbl), WGTP2 (dbl), WGTP3 (dbl), WGTP4 (dbl), WGTP5 (dbl), WGTP6 (dbl), WGTP7 (dbl), WGTP8
#>     (dbl), WGTP9 (dbl), WGTP10 (dbl), WGTP11 (dbl), WGTP12 (dbl), WGTP13 (dbl), WGTP14 (dbl), WGTP15 (dbl), WGTP16
#>     (dbl), WGTP17 (dbl), WGTP18 (dbl), WGTP19 (dbl), WGTP20 (dbl), WGTP21 (dbl), WGTP22 (dbl), WGTP23 (dbl), WGTP24
#>     (dbl), WGTP25 (dbl), WGTP26 (dbl), WGTP27 (dbl), WGTP28 (dbl), WGTP29 (dbl), WGTP30 (dbl), WGTP31 (dbl), WGTP32
#>     (dbl), WGTP33 (dbl), WGTP34 (dbl), WGTP35 (dbl), WGTP36 (dbl), WGTP37 (dbl), WGTP38 (dbl), WGTP39 (dbl), WGTP40
#>     (dbl), WGTP41 (dbl), WGTP42 (dbl), WGTP43 (dbl), WGTP44 (dbl), WGTP45 (dbl), WGTP46 (dbl), WGTP47 (dbl), WGTP48
#>     (dbl), WGTP49 (dbl), WGTP50 (dbl), WGTP51 (dbl), WGTP52 (dbl), WGTP53 (dbl), WGTP54 (dbl), WGTP55 (dbl), WGTP56
#>     (dbl), WGTP57 (dbl), WGTP58 (dbl), WGTP59 (dbl), WGTP60 (dbl), WGTP61 (dbl), WGTP62 (dbl), WGTP63 (dbl), WGTP64
#>     (dbl), WGTP65 (dbl), WGTP66 (dbl), WGTP67 (dbl), WGTP68 (dbl), WGTP69 (dbl), WGTP70 (dbl), WGTP71 (dbl), WGTP72
#>     (dbl), WGTP73 (dbl), WGTP74 (dbl), WGTP75 (dbl), WGTP76 (dbl), WGTP77 (dbl), WGTP78 (dbl), WGTP79 (dbl), WGTP80
#>     (dbl)
#> Variables: 
#>  [1] "SERIALNO" "SPORDER"  "NP"       "BDSP"     "HINCP"    "PUMA"     "ST"       "TYPEHUGQ" "WGTP"     "PWGTP"   
#> [11] "WGTP1"    "WGTP2"    "WGTP3"    "WGTP4"    "WGTP5"    "WGTP6"    "WGTP7"    "WGTP8"    "WGTP9"    "WGTP10"  
#> [21] "WGTP11"   "WGTP12"   "WGTP13"   "WGTP14"   "WGTP15"   "WGTP16"   "WGTP17"   "WGTP18"   "WGTP19"   "WGTP20"  
#> [31] "WGTP21"   "WGTP22"   "WGTP23"   "WGTP24"   "WGTP25"   "WGTP26"   "WGTP27"   "WGTP28"   "WGTP29"   "WGTP30"  
#> [41] "WGTP31"   "WGTP32"   "WGTP33"   "WGTP34"   "WGTP35"   "WGTP36"   "WGTP37"   "WGTP38"   "WGTP39"   "WGTP40"  
#> [51] "WGTP41"   "WGTP42"   "WGTP43"   "WGTP44"   "WGTP45"   "WGTP46"   "WGTP47"   "WGTP48"   "WGTP49"   "WGTP50"  
#> [61] "WGTP51"   "WGTP52"   "WGTP53"   "WGTP54"   "WGTP55"   "WGTP56"   "WGTP57"   "WGTP58"   "WGTP59"   "WGTP60"  
#> [71] "WGTP61"   "WGTP62"   "WGTP63"   "WGTP64"   "WGTP65"   "WGTP66"   "WGTP67"   "WGTP68"   "WGTP69"   "WGTP70"  
#> [81] "WGTP71"   "WGTP72"   "WGTP73"   "WGTP74"   "WGTP75"   "WGTP76"   "WGTP77"   "WGTP78"   "WGTP79"   "WGTP80"

options(width=60)
des_acs
#> Call: Called via srvyr
#> Unstratified cluster jacknife (JK1) with 80 replicates and MSE variances.
#> Sampling variables:
#>   - repweights: `WGTP1 + WGTP2 + WGTP3 + WGTP4 + WGTP5 +
#>     WGTP6 + WGTP7 + WGTP8 + WGTP9 + WGTP10 + WGTP11 +
#>     WGTP12 + WGTP13 + WGTP14 + WGTP15 + WGTP16 + WGTP17 +
#>     WGTP18 + WGTP19 + WGTP20 + WGTP21 + WGTP22 + WGTP23 +
#>     WGTP24 + WGTP25 + WGTP26 + WGTP27 + WGTP28 + WGTP29 +
#>     WGTP30 + WGTP31 + WGTP32 + WGTP33 + WGTP34 + WGTP35 +
#>     WGTP36 + WGTP37 + WGTP38 + WGTP39 + WGTP40 + WGTP41 +
#>     WGTP42 + WGTP43 + WGTP44 + WGTP45 + WGTP46 + WGTP47 +
#>     WGTP48 + WGTP49 + WGTP50 + WGTP51 + WGTP52 + WGTP53 +
#>     WGTP54 + WGTP55 + WGTP56 + WGTP57 + WGTP58 + WGTP59 +
#>     WGTP60 + WGTP61 + WGTP62 + WGTP63 + WGTP64 + WGTP65 +
#>     WGTP66 + WGTP67 + WGTP68 + WGTP69 + WGTP70 + WGTP71 +
#>     WGTP72 + WGTP73 + WGTP74 + WGTP75 + WGTP76 + WGTP77 +
#>     WGTP78 + WGTP79 + WGTP80` 
#>   - weights: WGTP 
#> Data variables: 
#>   - SERIALNO (chr), SPORDER (dbl), NP (dbl), BDSP (dbl),
#>     HINCP (dbl), PUMA (chr), ST (chr), TYPEHUGQ (chr), WGTP
#>     (dbl), PWGTP (dbl), WGTP1 (dbl), WGTP2 (dbl), WGTP3
#>     (dbl), WGTP4 (dbl), WGTP5 (dbl), WGTP6 (dbl), WGTP7
#>     (dbl), WGTP8 (dbl), WGTP9 (dbl), WGTP10 (dbl), WGTP11
#>     (dbl), WGTP12 (dbl), WGTP13 (dbl), WGTP14 (dbl), WGTP15
#>     (dbl), WGTP16 (dbl), WGTP17 (dbl), WGTP18 (dbl), WGTP19
#>     (dbl), WGTP20 (dbl), WGTP21 (dbl), WGTP22 (dbl), WGTP23
#>     (dbl), WGTP24 (dbl), WGTP25 (dbl), WGTP26 (dbl), WGTP27
#>     (dbl), WGTP28 (dbl), WGTP29 (dbl), WGTP30 (dbl), WGTP31
#>     (dbl), WGTP32 (dbl), WGTP33 (dbl), WGTP34 (dbl), WGTP35
#>     (dbl), WGTP36 (dbl), WGTP37 (dbl), WGTP38 (dbl), WGTP39
#>     (dbl), WGTP40 (dbl), WGTP41 (dbl), WGTP42 (dbl), WGTP43
#>     (dbl), WGTP44 (dbl), WGTP45 (dbl), WGTP46 (dbl), WGTP47
#>     (dbl), WGTP48 (dbl), WGTP49 (dbl), WGTP50 (dbl), WGTP51
#>     (dbl), WGTP52 (dbl), WGTP53 (dbl), WGTP54 (dbl), WGTP55
#>     (dbl), WGTP56 (dbl), WGTP57 (dbl), WGTP58 (dbl), WGTP59
#>     (dbl), WGTP60 (dbl), WGTP61 (dbl), WGTP62 (dbl), WGTP63
#>     (dbl), WGTP64 (dbl), WGTP65 (dbl), WGTP66 (dbl), WGTP67
#>     (dbl), WGTP68 (dbl), WGTP69 (dbl), WGTP70 (dbl), WGTP71
#>     (dbl), WGTP72 (dbl), WGTP73 (dbl), WGTP74 (dbl), WGTP75
#>     (dbl), WGTP76 (dbl), WGTP77 (dbl), WGTP78 (dbl), WGTP79
#>     (dbl), WGTP80 (dbl)
summary(des_acs)
#> Call: Called via srvyr
#> Unstratified cluster jacknife (JK1) with 80 replicates and MSE variances.
#> Sampling variables:
#>   - repweights: `WGTP1 + WGTP2 + WGTP3 + WGTP4 + WGTP5 +
#>     WGTP6 + WGTP7 + WGTP8 + WGTP9 + WGTP10 + WGTP11 +
#>     WGTP12 + WGTP13 + WGTP14 + WGTP15 + WGTP16 + WGTP17 +
#>     WGTP18 + WGTP19 + WGTP20 + WGTP21 + WGTP22 + WGTP23 +
#>     WGTP24 + WGTP25 + WGTP26 + WGTP27 + WGTP28 + WGTP29 +
#>     WGTP30 + WGTP31 + WGTP32 + WGTP33 + WGTP34 + WGTP35 +
#>     WGTP36 + WGTP37 + WGTP38 + WGTP39 + WGTP40 + WGTP41 +
#>     WGTP42 + WGTP43 + WGTP44 + WGTP45 + WGTP46 + WGTP47 +
#>     WGTP48 + WGTP49 + WGTP50 + WGTP51 + WGTP52 + WGTP53 +
#>     WGTP54 + WGTP55 + WGTP56 + WGTP57 + WGTP58 + WGTP59 +
#>     WGTP60 + WGTP61 + WGTP62 + WGTP63 + WGTP64 + WGTP65 +
#>     WGTP66 + WGTP67 + WGTP68 + WGTP69 + WGTP70 + WGTP71 +
#>     WGTP72 + WGTP73 + WGTP74 + WGTP75 + WGTP76 + WGTP77 +
#>     WGTP78 + WGTP79 + WGTP80` 
#>   - weights: WGTP 
#> Data variables: 
#>   - SERIALNO (chr), SPORDER (dbl), NP (dbl), BDSP (dbl),
#>     HINCP (dbl), PUMA (chr), ST (chr), TYPEHUGQ (chr), WGTP
#>     (dbl), PWGTP (dbl), WGTP1 (dbl), WGTP2 (dbl), WGTP3
#>     (dbl), WGTP4 (dbl), WGTP5 (dbl), WGTP6 (dbl), WGTP7
#>     (dbl), WGTP8 (dbl), WGTP9 (dbl), WGTP10 (dbl), WGTP11
#>     (dbl), WGTP12 (dbl), WGTP13 (dbl), WGTP14 (dbl), WGTP15
#>     (dbl), WGTP16 (dbl), WGTP17 (dbl), WGTP18 (dbl), WGTP19
#>     (dbl), WGTP20 (dbl), WGTP21 (dbl), WGTP22 (dbl), WGTP23
#>     (dbl), WGTP24 (dbl), WGTP25 (dbl), WGTP26 (dbl), WGTP27
#>     (dbl), WGTP28 (dbl), WGTP29 (dbl), WGTP30 (dbl), WGTP31
#>     (dbl), WGTP32 (dbl), WGTP33 (dbl), WGTP34 (dbl), WGTP35
#>     (dbl), WGTP36 (dbl), WGTP37 (dbl), WGTP38 (dbl), WGTP39
#>     (dbl), WGTP40 (dbl), WGTP41 (dbl), WGTP42 (dbl), WGTP43
#>     (dbl), WGTP44 (dbl), WGTP45 (dbl), WGTP46 (dbl), WGTP47
#>     (dbl), WGTP48 (dbl), WGTP49 (dbl), WGTP50 (dbl), WGTP51
#>     (dbl), WGTP52 (dbl), WGTP53 (dbl), WGTP54 (dbl), WGTP55
#>     (dbl), WGTP56 (dbl), WGTP57 (dbl), WGTP58 (dbl), WGTP59
#>     (dbl), WGTP60 (dbl), WGTP61 (dbl), WGTP62 (dbl), WGTP63
#>     (dbl), WGTP64 (dbl), WGTP65 (dbl), WGTP66 (dbl), WGTP67
#>     (dbl), WGTP68 (dbl), WGTP69 (dbl), WGTP70 (dbl), WGTP71
#>     (dbl), WGTP72 (dbl), WGTP73 (dbl), WGTP74 (dbl), WGTP75
#>     (dbl), WGTP76 (dbl), WGTP77 (dbl), WGTP78 (dbl), WGTP79
#>     (dbl), WGTP80 (dbl)
#> Variables: 
#>  [1] "SERIALNO" "SPORDER"  "NP"       "BDSP"     "HINCP"   
#>  [6] "PUMA"     "ST"       "TYPEHUGQ" "WGTP"     "PWGTP"   
#> [11] "WGTP1"    "WGTP2"    "WGTP3"    "WGTP4"    "WGTP5"   
#> [16] "WGTP6"    "WGTP7"    "WGTP8"    "WGTP9"    "WGTP10"  
#> [21] "WGTP11"   "WGTP12"   "WGTP13"   "WGTP14"   "WGTP15"  
#> [26] "WGTP16"   "WGTP17"   "WGTP18"   "WGTP19"   "WGTP20"  
#> [31] "WGTP21"   "WGTP22"   "WGTP23"   "WGTP24"   "WGTP25"  
#> [36] "WGTP26"   "WGTP27"   "WGTP28"   "WGTP29"   "WGTP30"  
#> [41] "WGTP31"   "WGTP32"   "WGTP33"   "WGTP34"   "WGTP35"  
#> [46] "WGTP36"   "WGTP37"   "WGTP38"   "WGTP39"   "WGTP40"  
#> [51] "WGTP41"   "WGTP42"   "WGTP43"   "WGTP44"   "WGTP45"  
#> [56] "WGTP46"   "WGTP47"   "WGTP48"   "WGTP49"   "WGTP50"  
#> [61] "WGTP51"   "WGTP52"   "WGTP53"   "WGTP54"   "WGTP55"  
#> [66] "WGTP56"   "WGTP57"   "WGTP58"   "WGTP59"   "WGTP60"  
#> [71] "WGTP61"   "WGTP62"   "WGTP63"   "WGTP64"   "WGTP65"  
#> [76] "WGTP66"   "WGTP67"   "WGTP68"   "WGTP69"   "WGTP70"  
#> [81] "WGTP71"   "WGTP72"   "WGTP73"   "WGTP74"   "WGTP75"  
#> [86] "WGTP76"   "WGTP77"   "WGTP78"   "WGTP79"   "WGTP80"


# Looking at grouping variables

des_acs %>% group_by(BDSP) 
#> Call: Called via srvyr
#> Unstratified cluster jacknife (JK1) with 80 replicates and MSE variances.
#> Sampling variables:
#>   - repweights: `WGTP1 + WGTP2 + WGTP3 + WGTP4 + WGTP5 +
#>     WGTP6 + WGTP7 + WGTP8 + WGTP9 + WGTP10 + WGTP11 +
#>     WGTP12 + WGTP13 + WGTP14 + WGTP15 + WGTP16 + WGTP17 +
#>     WGTP18 + WGTP19 + WGTP20 + WGTP21 + WGTP22 + WGTP23 +
#>     WGTP24 + WGTP25 + WGTP26 + WGTP27 + WGTP28 + WGTP29 +
#>     WGTP30 + WGTP31 + WGTP32 + WGTP33 + WGTP34 + WGTP35 +
#>     WGTP36 + WGTP37 + WGTP38 + WGTP39 + WGTP40 + WGTP41 +
#>     WGTP42 + WGTP43 + WGTP44 + WGTP45 + WGTP46 + WGTP47 +
#>     WGTP48 + WGTP49 + WGTP50 + WGTP51 + WGTP52 + WGTP53 +
#>     WGTP54 + WGTP55 + WGTP56 + WGTP57 + WGTP58 + WGTP59 +
#>     WGTP60 + WGTP61 + WGTP62 + WGTP63 + WGTP64 + WGTP65 +
#>     WGTP66 + WGTP67 + WGTP68 + WGTP69 + WGTP70 + WGTP71 +
#>     WGTP72 + WGTP73 + WGTP74 + WGTP75 + WGTP76 + WGTP77 +
#>     WGTP78 + WGTP79 + WGTP80` 
#>   - weights: WGTP 
#> Grouping variables: 
#>   - BDSP
#> Data variables: 
#>   - SERIALNO (chr), SPORDER (dbl), NP (dbl), BDSP (dbl),
#>     HINCP (dbl), PUMA (chr), ST (chr), TYPEHUGQ (chr), WGTP
#>     (dbl), PWGTP (dbl), WGTP1 (dbl), WGTP2 (dbl), WGTP3
#>     (dbl), WGTP4 (dbl), WGTP5 (dbl), WGTP6 (dbl), WGTP7
#>     (dbl), WGTP8 (dbl), WGTP9 (dbl), WGTP10 (dbl), WGTP11
#>     (dbl), WGTP12 (dbl), WGTP13 (dbl), WGTP14 (dbl), WGTP15
#>     (dbl), WGTP16 (dbl), WGTP17 (dbl), WGTP18 (dbl), WGTP19
#>     (dbl), WGTP20 (dbl), WGTP21 (dbl), WGTP22 (dbl), WGTP23
#>     (dbl), WGTP24 (dbl), WGTP25 (dbl), WGTP26 (dbl), WGTP27
#>     (dbl), WGTP28 (dbl), WGTP29 (dbl), WGTP30 (dbl), WGTP31
#>     (dbl), WGTP32 (dbl), WGTP33 (dbl), WGTP34 (dbl), WGTP35
#>     (dbl), WGTP36 (dbl), WGTP37 (dbl), WGTP38 (dbl), WGTP39
#>     (dbl), WGTP40 (dbl), WGTP41 (dbl), WGTP42 (dbl), WGTP43
#>     (dbl), WGTP44 (dbl), WGTP45 (dbl), WGTP46 (dbl), WGTP47
#>     (dbl), WGTP48 (dbl), WGTP49 (dbl), WGTP50 (dbl), WGTP51
#>     (dbl), WGTP52 (dbl), WGTP53 (dbl), WGTP54 (dbl), WGTP55
#>     (dbl), WGTP56 (dbl), WGTP57 (dbl), WGTP58 (dbl), WGTP59
#>     (dbl), WGTP60 (dbl), WGTP61 (dbl), WGTP62 (dbl), WGTP63
#>     (dbl), WGTP64 (dbl), WGTP65 (dbl), WGTP66 (dbl), WGTP67
#>     (dbl), WGTP68 (dbl), WGTP69 (dbl), WGTP70 (dbl), WGTP71
#>     (dbl), WGTP72 (dbl), WGTP73 (dbl), WGTP74 (dbl), WGTP75
#>     (dbl), WGTP76 (dbl), WGTP77 (dbl), WGTP78 (dbl), WGTP79
#>     (dbl), WGTP80 (dbl)
des_acs %>% group_by(BDSP) %>% summary()
#> Call: Called via srvyr
#> Unstratified cluster jacknife (JK1) with 80 replicates and MSE variances.
#> Sampling variables:
#>   - repweights: `WGTP1 + WGTP2 + WGTP3 + WGTP4 + WGTP5 +
#>     WGTP6 + WGTP7 + WGTP8 + WGTP9 + WGTP10 + WGTP11 +
#>     WGTP12 + WGTP13 + WGTP14 + WGTP15 + WGTP16 + WGTP17 +
#>     WGTP18 + WGTP19 + WGTP20 + WGTP21 + WGTP22 + WGTP23 +
#>     WGTP24 + WGTP25 + WGTP26 + WGTP27 + WGTP28 + WGTP29 +
#>     WGTP30 + WGTP31 + WGTP32 + WGTP33 + WGTP34 + WGTP35 +
#>     WGTP36 + WGTP37 + WGTP38 + WGTP39 + WGTP40 + WGTP41 +
#>     WGTP42 + WGTP43 + WGTP44 + WGTP45 + WGTP46 + WGTP47 +
#>     WGTP48 + WGTP49 + WGTP50 + WGTP51 + WGTP52 + WGTP53 +
#>     WGTP54 + WGTP55 + WGTP56 + WGTP57 + WGTP58 + WGTP59 +
#>     WGTP60 + WGTP61 + WGTP62 + WGTP63 + WGTP64 + WGTP65 +
#>     WGTP66 + WGTP67 + WGTP68 + WGTP69 + WGTP70 + WGTP71 +
#>     WGTP72 + WGTP73 + WGTP74 + WGTP75 + WGTP76 + WGTP77 +
#>     WGTP78 + WGTP79 + WGTP80` 
#>   - weights: WGTP 
#> Grouping variables: 
#>   - BDSP
#> Data variables: 
#>   - SERIALNO (chr), SPORDER (dbl), NP (dbl), BDSP (dbl),
#>     HINCP (dbl), PUMA (chr), ST (chr), TYPEHUGQ (chr), WGTP
#>     (dbl), PWGTP (dbl), WGTP1 (dbl), WGTP2 (dbl), WGTP3
#>     (dbl), WGTP4 (dbl), WGTP5 (dbl), WGTP6 (dbl), WGTP7
#>     (dbl), WGTP8 (dbl), WGTP9 (dbl), WGTP10 (dbl), WGTP11
#>     (dbl), WGTP12 (dbl), WGTP13 (dbl), WGTP14 (dbl), WGTP15
#>     (dbl), WGTP16 (dbl), WGTP17 (dbl), WGTP18 (dbl), WGTP19
#>     (dbl), WGTP20 (dbl), WGTP21 (dbl), WGTP22 (dbl), WGTP23
#>     (dbl), WGTP24 (dbl), WGTP25 (dbl), WGTP26 (dbl), WGTP27
#>     (dbl), WGTP28 (dbl), WGTP29 (dbl), WGTP30 (dbl), WGTP31
#>     (dbl), WGTP32 (dbl), WGTP33 (dbl), WGTP34 (dbl), WGTP35
#>     (dbl), WGTP36 (dbl), WGTP37 (dbl), WGTP38 (dbl), WGTP39
#>     (dbl), WGTP40 (dbl), WGTP41 (dbl), WGTP42 (dbl), WGTP43
#>     (dbl), WGTP44 (dbl), WGTP45 (dbl), WGTP46 (dbl), WGTP47
#>     (dbl), WGTP48 (dbl), WGTP49 (dbl), WGTP50 (dbl), WGTP51
#>     (dbl), WGTP52 (dbl), WGTP53 (dbl), WGTP54 (dbl), WGTP55
#>     (dbl), WGTP56 (dbl), WGTP57 (dbl), WGTP58 (dbl), WGTP59
#>     (dbl), WGTP60 (dbl), WGTP61 (dbl), WGTP62 (dbl), WGTP63
#>     (dbl), WGTP64 (dbl), WGTP65 (dbl), WGTP66 (dbl), WGTP67
#>     (dbl), WGTP68 (dbl), WGTP69 (dbl), WGTP70 (dbl), WGTP71
#>     (dbl), WGTP72 (dbl), WGTP73 (dbl), WGTP74 (dbl), WGTP75
#>     (dbl), WGTP76 (dbl), WGTP77 (dbl), WGTP78 (dbl), WGTP79
#>     (dbl), WGTP80 (dbl)
#> Variables: 
#>  [1] "SERIALNO" "SPORDER"  "NP"       "BDSP"     "HINCP"   
#>  [6] "PUMA"     "ST"       "TYPEHUGQ" "WGTP"     "PWGTP"   
#> [11] "WGTP1"    "WGTP2"    "WGTP3"    "WGTP4"    "WGTP5"   
#> [16] "WGTP6"    "WGTP7"    "WGTP8"    "WGTP9"    "WGTP10"  
#> [21] "WGTP11"   "WGTP12"   "WGTP13"   "WGTP14"   "WGTP15"  
#> [26] "WGTP16"   "WGTP17"   "WGTP18"   "WGTP19"   "WGTP20"  
#> [31] "WGTP21"   "WGTP22"   "WGTP23"   "WGTP24"   "WGTP25"  
#> [36] "WGTP26"   "WGTP27"   "WGTP28"   "WGTP29"   "WGTP30"  
#> [41] "WGTP31"   "WGTP32"   "WGTP33"   "WGTP34"   "WGTP35"  
#> [46] "WGTP36"   "WGTP37"   "WGTP38"   "WGTP39"   "WGTP40"  
#> [51] "WGTP41"   "WGTP42"   "WGTP43"   "WGTP44"   "WGTP45"  
#> [56] "WGTP46"   "WGTP47"   "WGTP48"   "WGTP49"   "WGTP50"  
#> [61] "WGTP51"   "WGTP52"   "WGTP53"   "WGTP54"   "WGTP55"  
#> [66] "WGTP56"   "WGTP57"   "WGTP58"   "WGTP59"   "WGTP60"  
#> [71] "WGTP61"   "WGTP62"   "WGTP63"   "WGTP64"   "WGTP65"  
#> [76] "WGTP66"   "WGTP67"   "WGTP68"   "WGTP69"   "WGTP70"  
#> [81] "WGTP71"   "WGTP72"   "WGTP73"   "WGTP74"   "WGTP75"  
#> [86] "WGTP76"   "WGTP77"   "WGTP78"   "WGTP79"   "WGTP80"

# Other designs

library(survey)
#> Loading required package: grid
#> Loading required package: Matrix
#> 
#> Attaching package: 'Matrix'
#> The following objects are masked from 'package:tidyr':
#> 
#>     expand, pack, unpack
#> Loading required package: survival
#> 
#> Attaching package: 'survey'
#> The following object is masked from 'package:graphics':
#> 
#>     dotchart
data(api)

apistrat %>% as_survey_design(strata = stype, weights = pw)
#> Stratified Independent Sampling design (with replacement)
#> Called via srvyr
#> Sampling variables:
#>   - ids: `1` 
#>   - strata: stype 
#>   - weights: pw 
#> Data variables: 
#>   - cds (chr), stype (fct), name (chr), sname (chr), snum
#>     (dbl), dname (chr), dnum (int), cname (chr), cnum
#>     (int), flag (int), pcttest (int), api00 (int), api99
#>     (int), target (int), growth (int), sch.wide (fct),
#>     comp.imp (fct), both (fct), awards (fct), meals (int),
#>     ell (int), yr.rnd (fct), mobility (int), acs.k3 (int),
#>     acs.46 (int), acs.core (int), pct.resp (int), not.hsg
#>     (int), hsg (int), some.col (int), col.grad (int),
#>     grad.sch (int), avg.ed (dbl), full (int), emer (int),
#>     enroll (int), api.stu (int), pw (dbl), fpc (dbl)

apiclus1 %>% as_survey_design(dnum, weights = pw, fpc = fpc)
#> 1 - level Cluster Sampling design
#> With (15) clusters.
#> Called via srvyr
#> Sampling variables:
#>   - ids: dnum 
#>   - fpc: fpc 
#>   - weights: pw 
#> Data variables: 
#>   - cds (chr), stype (fct), name (chr), sname (chr), snum
#>     (dbl), dname (chr), dnum (int), cname (chr), cnum
#>     (int), flag (int), pcttest (int), api00 (int), api99
#>     (int), target (int), growth (int), sch.wide (fct),
#>     comp.imp (fct), both (fct), awards (fct), meals (int),
#>     ell (int), yr.rnd (fct), mobility (int), acs.k3 (int),
#>     acs.46 (int), acs.core (int), pct.resp (int), not.hsg
#>     (int), hsg (int), some.col (int), col.grad (int),
#>     grad.sch (int), avg.ed (dbl), full (int), emer (int),
#>     enroll (int), api.stu (int), fpc (dbl), pw (dbl)

apiclus2 %>% as_survey_design(c(dnum, snum), fpc = c(fpc1, fpc2))
#> 2 - level Cluster Sampling design
#> With (40, 126) clusters.
#> Called via srvyr
#> Sampling variables:
#>   - ids: `dnum + snum` 
#>   - fpc: `fpc1 + fpc2` 
#> Data variables: 
#>   - cds (chr), stype (fct), name (chr), sname (chr), snum
#>     (dbl), dname (chr), dnum (int), cname (chr), cnum
#>     (int), flag (int), pcttest (int), api00 (int), api99
#>     (int), target (int), growth (int), sch.wide (fct),
#>     comp.imp (fct), both (fct), awards (fct), meals (int),
#>     ell (int), yr.rnd (fct), mobility (int), acs.k3 (int),
#>     acs.46 (int), acs.core (int), pct.resp (int), not.hsg
#>     (int), hsg (int), some.col (int), col.grad (int),
#>     grad.sch (int), avg.ed (dbl), full (int), emer (int),
#>     enroll (int), api.stu (int), pw (dbl), fpc1 (dbl), fpc2
#>     (int[1d])

apistrat %>% as_survey_design(dnum, strata = stype, weights = pw,
                              nest = TRUE)
#> Stratified 1 - level Cluster Sampling design (with replacement)
#> With (162) clusters.
#> Called via srvyr
#> Sampling variables:
#>   - ids: dnum 
#>   - strata: stype 
#>   - weights: pw 
#> Data variables: 
#>   - cds (chr), stype (fct), name (chr), sname (chr), snum
#>     (dbl), dname (chr), dnum (int), cname (chr), cnum
#>     (int), flag (int), pcttest (int), api00 (int), api99
#>     (int), target (int), growth (int), sch.wide (fct),
#>     comp.imp (fct), both (fct), awards (fct), meals (int),
#>     ell (int), yr.rnd (fct), mobility (int), acs.k3 (int),
#>     acs.46 (int), acs.core (int), pct.resp (int), not.hsg
#>     (int), hsg (int), some.col (int), col.grad (int),
#>     grad.sch (int), avg.ed (dbl), full (int), emer (int),
#>     enroll (int), api.stu (int), pw (dbl), fpc (dbl)

data(election)
election_pps %>% as_survey_design(fpc = p, pps = "brewer")
#> Independent Sampling design
#> Called via srvyr
#> Sampling variables:
#>   - ids: `1` 
#>   - fpc: p 
#> Data variables: 
#>   - County (fct), TotPrecincts (int), PrecinctsReporting
#>     (int), Bush (int), Kerry (int), Nader (int), votes
#>     (int), p (dbl), wt (dbl)

# When creating a replicate object from design object, there are no sampling variables!

ex1 <- apistrat %>% as_survey_design(strata = stype, weights = pw) %>% 
  as_survey_rep()
ex1
#> Call: Called via srvyr
#> Stratified cluster jackknife (JKn) with 200 replicates.
#> Data variables: 
#>   - cds (chr), stype (fct), name (chr), sname (chr), snum
#>     (dbl), dname (chr), dnum (int), cname (chr), cnum
#>     (int), flag (int), pcttest (int), api00 (int), api99
#>     (int), target (int), growth (int), sch.wide (fct),
#>     comp.imp (fct), both (fct), awards (fct), meals (int),
#>     ell (int), yr.rnd (fct), mobility (int), acs.k3 (int),
#>     acs.46 (int), acs.core (int), pct.resp (int), not.hsg
#>     (int), hsg (int), some.col (int), col.grad (int),
#>     grad.sch (int), avg.ed (dbl), full (int), emer (int),
#>     enroll (int), api.stu (int), pw (dbl), fpc (dbl)
attr(ex1, "survey_vars")
#> Sampling variables:

ex2 <- apiclus1 %>% as_survey_design(dnum, weights = pw, fpc = fpc) %>%
  as_survey_rep() 
ex2
#> Call: Called via srvyr
#> Unstratified cluster jacknife (JK1) with 15 replicates.
#> Data variables: 
#>   - cds (chr), stype (fct), name (chr), sname (chr), snum
#>     (dbl), dname (chr), dnum (int), cname (chr), cnum
#>     (int), flag (int), pcttest (int), api00 (int), api99
#>     (int), target (int), growth (int), sch.wide (fct),
#>     comp.imp (fct), both (fct), awards (fct), meals (int),
#>     ell (int), yr.rnd (fct), mobility (int), acs.k3 (int),
#>     acs.46 (int), acs.core (int), pct.resp (int), not.hsg
#>     (int), hsg (int), some.col (int), col.grad (int),
#>     grad.sch (int), avg.ed (dbl), full (int), emer (int),
#>     enroll (int), api.stu (int), fpc (dbl), pw (dbl)
attr(ex2, "survey_vars")
#> Sampling variables:
```

<sup>Created on 2023-09-10 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
