### PR TITLE
Some speedup

### DIFF
--- a/R/survey_statistics_helpers.R
+++ b/R/survey_statistics_helpers.R
@@ -43,7 +43,7 @@ set_survey_vars <- function(
     out$phase1$sample$variables[[name]] <- x
   } else {
     if (!add) {
-      out$variables <- out$variables[group_vars(out)]
+      out$variables <- out$variables[, group_vars(out), drop = FALSE]
     }
     out$variables[[name]] <- x
   }

--- a/R/survey_statistics_helpers.R
+++ b/R/survey_statistics_helpers.R
@@ -43,7 +43,7 @@ set_survey_vars <- function(
     out$phase1$sample$variables[[name]] <- x
   } else {
     if (!add) {
-      out$variables <- out$variables[, group_vars(out), drop = FALSE]
+      out$variables <- out$variables[group_vars(out)]
     }
     out$variables[[name]] <- x
   }

--- a/R/survey_statistics_helpers.R
+++ b/R/survey_statistics_helpers.R
@@ -122,7 +122,7 @@ get_var_est <- function(
     }
   })
 
-  coef <- as.data.frame(coef(stat))
+  coef <- as.data.frame(unclass(coef(stat)))
   names(coef) <- "coef"
   out <- c(list(coef), out)
 

--- a/R/survey_statistics_helpers.R
+++ b/R/survey_statistics_helpers.R
@@ -43,7 +43,7 @@ set_survey_vars <- function(
     out$phase1$sample$variables[[name]] <- x
   } else {
     if (!add) {
-      out$variables <- select(out$variables, dplyr::one_of(group_vars(out)))
+      out$variables <- out$variables[, group_vars(out), drop = FALSE]
     }
     out$variables[[name]] <- x
   }
@@ -83,7 +83,7 @@ get_var_est <- function(
       se <- survey::SE(stat)
       # Needed for grouped quantile
       if (!inherits(se, "data.frame")) {
-        se <- data.frame(matrix(se, ncol = out_width))
+        se <- as.data.frame(se)
       }
       names(se) <- "_se"
       se
@@ -122,7 +122,7 @@ get_var_est <- function(
     }
   })
 
-  coef <- data.frame(matrix(coef(stat), ncol = out_width))
+  coef <- as.data.frame(coef(stat))
   names(coef) <- "coef"
   out <- c(list(coef), out)
 
@@ -136,7 +136,7 @@ get_var_est <- function(
     out <- c(out, list(deff))
   }
 
-  as_srvyr_result_df(dplyr::bind_cols(out))
+  as_srvyr_result_df(do.call(cbind, out))
 }
 
 # Largely the same as get_var_est(), but need to handle the fact that there can be


### PR DESCRIPTION
Hi @gergness @bschneidr, following #164, I tried to explore how the performance of `srvyr` can be improved. Indeed, most of the time is spent on `survey` functions, but a few `dplyr` functions (mostly `select()`) could be replaced with their base R equivalent (`select()` is not that slow, but it has some overhead that is repeated thousands of times). I didn't check if there were more instances where `select()` can be replaced, I only looked at the functions called in the example in #164.

Here's a benchmark comparing `main` with this PR. The package `cross` is not on CRAN, it can be found here: https://github.com/davisVaughan/cross. It allows to compare the same code with both branches separately.

``` r
library(bench) 
library(dplyr)

out <- cross::run(
  pkgs = c("gergness/srvyr", "etiennebacher/srvyr@speedup"), 
  ~{
    library(dplyr)
    library(srvyr)
    N <- 20000
    set.seed(123)
    
    test <- data.frame(
      grp1 = sample(letters, N, TRUE),
      grp2 = sample(LETTERS, N, TRUE),
      grp3 = sample(1:10, N, TRUE),
      weight = sample(seq(0, 1, 0.01), N, TRUE)
    ) |> 
      arrange(grp1, grp2, grp3)
    
    test_sv <- as_survey_design(test, weights = weight)
    
    bench::mark(
      test_sv |> 
        group_by(grp1, grp2, grp3) |> 
        survey_count(),
      iterations = 15
    )
    
  }
)

tidyr::unnest(out, result) |> 
  select(pkg, median, mem_alloc)
#> # A tibble: 2 × 3
#>   pkg                           median mem_alloc
#>   <chr>                       <bch:tm> <bch:byt>
#> 1 gergness/srvyr                 32.7s      16GB
#> 2 etiennebacher/srvyr@speedup    19.9s    15.9GB
```
