### PR TITLE
Add degf option to `as_survey_rep()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# (development)
+* `as_survey_rep()` now has an argument `degf`, corresponding to the same argument in the survey function `svrepdesign()`. This argument can be useful for large data sets, since specifying a value for `degf` avoids a calculation which can be slow for very large data sets.
+
 # srvyr 1.2.0
 * `survey_prop()` now uses proportions as the default, which should confidence interval improve coverage, but does mean results may slightly change (#141, #142, thanks @szimmer)
 * New function `survey_corr()` calculates the correlation between 2 variables, (#150, #151, thanks @szimmer & @bschneidr)

--- a/R/as_survey_rep.r
+++ b/R/as_survey_rep.r
@@ -32,6 +32,10 @@
 #' @param fpctype Finite population correction information
 #' @param mse if \code{TRUE}, compute variances based on sum of squares
 #' around the point estimate, rather than the mean of the replicates
+#' @param degf Design degrees of freedom: a single number, or \code{NULL},
+#' in which case a value will be computed automatically, which can be slow
+#' for very large data sets. See \code{\link[survey]{svrepdesign}}
+#' for more details.
 #' @param ... ignored
 #' @param compress if \code{TRUE}, store replicate weights in compressed form
 #' (if converting from design)
@@ -73,7 +77,7 @@ as_survey_rep.data.frame <-
                     "other"), combined_weights = TRUE,
            rho = NULL, bootstrap_average = NULL, scale = NULL,
            rscales = NULL, fpc = NULL, fpctype = c("fraction", "correction"),
-           mse = getOption("survey.replicates.mse"), ...) {
+           mse = getOption("survey.replicates.mse"), degf = NULL, ...) {
     variables <- srvyr_select_vars(rlang::enquo(variables), .data)
     repweights <- srvyr_select_vars(rlang::enquo(repweights), .data)
     weights <- srvyr_select_vars(rlang::enquo(weights), .data)
@@ -85,6 +89,7 @@ as_survey_rep.data.frame <-
       repweights = repweights,
       weights = weights,
       data = .data,
+      degf = degf,
       type = type,
       combined.weights = combined_weights,
       rho = rho,
@@ -112,7 +117,7 @@ as_survey_rep.tbl_lazy <-
                     "other"), combined_weights = TRUE,
            rho = NULL, bootstrap_average = NULL, scale = NULL,
            rscales = NULL, fpc = NULL, fpctype = c("fraction", "correction"),
-           mse = getOption("survey.replicates.mse"), ...) {
+           mse = getOption("survey.replicates.mse"), degf = NULL, ...) {
 
     variables <- rlang::enquo(variables)
     repweights <- rlang::enquo(repweights)
@@ -134,6 +139,7 @@ as_survey_rep.tbl_lazy <-
       repweights = repweights,
       weights = weights,
       data = survey_vars_local,
+      degf = degf,
       type = type,
       combined.weights = combined_weights,
       rho = rho,

--- a/man/as_survey_rep.Rd
+++ b/man/as_survey_rep.Rd
@@ -26,6 +26,7 @@ as_survey_rep(.data, ...)
   fpc = NULL,
   fpctype = c("fraction", "correction"),
   mse = getOption("survey.replicates.mse"),
+  degf = NULL,
   ...
 )
 
@@ -44,6 +45,7 @@ as_survey_rep(.data, ...)
   fpc = NULL,
   fpctype = c("fraction", "correction"),
   mse = getOption("survey.replicates.mse"),
+  degf = NULL,
   ...
 )
 
@@ -104,6 +106,11 @@ weights have been averaged, gives the number of iterations averaged over.}
 
 \item{mse}{if \code{TRUE}, compute variances based on sum of squares
 around the point estimate, rather than the mean of the replicates}
+
+\item{degf}{Design degrees of freedom: a single number, or \code{NULL},
+in which case a value will be computed automatically, which can be slow
+for very large data sets. See \code{\link[survey]{svrepdesign}}
+for more details.}
 
 \item{compress}{if \code{TRUE}, store replicate weights in compressed form
 (if converting from design)}

--- a/tests/testthat/test_as_survey_rep.r
+++ b/tests/testthat/test_as_survey_rep.r
@@ -228,3 +228,18 @@ test_that("as_survey_rep works when using SDR/ACS method of replicate weights", 
   expect_equal(c(out_survey[[1]], sqrt(attr(out_survey, "var"))),
                c(out_srvyr_acs[[1]][[1]], out_srvyr_acs[[2]][[1]]))
 })
+
+# ------------------------------------------------------------------
+# Test user-specified degrees of freedom
+# ------------------------------------------------------------------
+
+sdr_srvyr <- cbind(sdr_sample, as.data.frame(sdr_factors)) %>%
+  as_survey_rep(repweights = starts_with("REP_"),
+                weights = "weights",
+                type = "successive-difference",
+                combined = FALSE,
+                degf = 4)
+
+test_that("as_survey_rep accepts user-specified degf", {
+  expect_equal(degf(sdr_srvyr), 4)
+})

--- a/vignettes/srvyr-database.Rmd
+++ b/vignettes/srvyr-database.Rmd
@@ -187,6 +187,8 @@ it will save a lot space.
 object.size(acs_m_db_svy)
 ```
 
+For very large survey data sets with replicate weights, it is strongly recommended to specify a value in the `degf` parameter of `as_survey_rep()`: otherwise, the survey package will attempt to automatically determine the design degrees of freedom using a process that can be very slow for large data sets. The value to use for `degf` will often be specified in survey data documentation, but a common rule of thumb is the number of columns of replicate weights.
+
 # Analysis # 
 
 Analysis commands from srvyr are also similar to ones that work on local data.frames. 


### PR DESCRIPTION
This PR brings `as_survey_rep()` up-to-date with an update to `svrepdesign()` in the latest release of the 'survey' package.

https://cran.r-project.org/web/packages/survey/NEWS
> allow user to specify degf= in svrepdesign to avoid needing to compute it (for Ben Schneider)

The updates include:

1. Adding `degf` as an argument in `as_survey_rep()`, behind `mse`, with accompanying roxygen2 documentation
2. Adding a small unit test
3. Updating the NEWS.md file
4. Adding a couple sentences to the databases vignette, since this update is useful for large data sets, which is the main motivation for using a database-backed survey, I think.

# Background
The motivation behind this change in the 'survey' package is that when Thomas Lumley updated `degf()` in version 3.3 of 'survey', it was [a good idea from a statistical perspective](https://notstatschat.rbind.io/2019/06/08/design-degrees-of-freedom-brief-note/) but introduced problems when working with large datasets, since it requires an expensive matrix decomposition of the replicate weights. So when working with large datasets like ACS microdata, the function `svrepdesign()` could crash or take up a lot of time and memory just to calculate the design degrees of freedom. This update to 'survey' and 'srvyr' allows the user to bypass this by manually specifying the degrees of freedom.