### PR TITLE
Allow `.by` to take multiple arguments

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -16,7 +16,7 @@ mutate.tbl_svy <- function(
 
   .by <- rlang::enquos(.by)
   # Can't just pass `.by` to dplyr because we need to calculate survey statistics per group
-  if (!is.null(.by)) {
+  if (!all(sapply(.by, rlang::quo_is_null))) {
     .data <- group_by(.data, across(!!!.by))
     return(mutate(.data, !!!dots, .keep = .keep, .before = {{.before}}, .after = {{.after}}, .unpack = .unpack))
   }

--- a/R/manip.r
+++ b/R/manip.r
@@ -14,10 +14,10 @@ mutate.tbl_svy <- function(
     stop("Cannot modify survey variable")
   }
 
-  .by <- rlang::enquo(.by)
+  .by <- rlang::enquos(.by)
   # Can't just pass `.by` to dplyr because we need to calculate survey statistics per group
-  if (!rlang::quo_is_null(.by)) {
-    .data <- group_by(.data, !!.by)
+  if (!is.null(.by)) {
+    .data <- group_by(.data, across(!!!.by))
     return(mutate(.data, !!!dots, .keep = .keep, .before = {{.before}}, .after = {{.after}}, .unpack = .unpack))
   }
 

--- a/R/summarise.r
+++ b/R/summarise.r
@@ -4,7 +4,7 @@ summarise.tbl_svy <- function(.data, ..., .by = NULL, .groups = NULL, .unpack = 
   .by <- rlang::enquos(.by)
 
   # Can't just pass `.by` to dplyr because we need to calculate survey statistics per group
-  if (!is.null(.by)) {
+  if (!all(sapply(.by, rlang::quo_is_null))) {
     .data <- group_by(.data, across(!!!.by))
     return(summarise(.data, !!!.dots, .groups = .groups, .unpack = .unpack))
   }

--- a/R/summarise.r
+++ b/R/summarise.r
@@ -1,11 +1,11 @@
 #' @export
 summarise.tbl_svy <- function(.data, ..., .by = NULL, .groups = NULL, .unpack = TRUE) {
   .dots <- rlang::quos(...)
-  .by <- rlang::enquo(.by)
+  .by <- rlang::enquos(.by)
 
   # Can't just pass `.by` to dplyr because we need to calculate survey statistics per group
-  if (!rlang::quo_is_null(.by)) {
-    .data <- group_by(.data, !!.by)
+  if (!is.null(.by)) {
+    .data <- group_by(.data, across(!!!.by))
     return(summarise(.data, !!!.dots, .groups = .groups, .unpack = .unpack))
   }
 

--- a/tests/testthat/test_dplyr_verbs.R
+++ b/tests/testthat/test_dplyr_verbs.R
@@ -43,6 +43,17 @@ test_that("mutate can handle .by", {
   expect_equal(explicit_group_by, .by_arg)
 })
 
+test_that("mutate can handle multiple .by", {
+  explicit_group_by <- dstrata %>%
+    group_by(name, awards) %>%
+    mutate(x = survey_mean(api99))
+
+  .by_arg <- dstrata %>%
+    mutate(x = survey_mean(api99), .by = c(name, awards))
+
+  expect_equal(explicit_group_by, .by_arg)
+})
+
 test_that('transmute works',{
   expect_equal(
     dstrata %>% transmute(test = 1),


### PR DESCRIPTION
This replicates the behaviour of the `.by` argument in `dplyr` for the `summarise` and `mutate` functions, allowing for multiple arguments to be passed in a vector.

Closes #192 