### PR TITLE
Match `dplyr` grouping behaviour for `.by`

### DIFF
--- a/R/manip.r
+++ b/R/manip.r
@@ -18,7 +18,7 @@ mutate.tbl_svy <- function(
   # Can't just pass `.by` to dplyr because we need to calculate survey statistics per group
   if (!all(sapply(.by, rlang::quo_is_null))) {
     .data <- group_by(.data, across(!!!.by))
-    return(mutate(.data, !!!dots, .keep = .keep, .before = {{.before}}, .after = {{.after}}, .unpack = .unpack))
+    return(ungroup(mutate(.data, !!!dots, .keep = .keep, .before = {{.before}}, .after = {{.after}}, .unpack = .unpack)))
   }
 
   # Set current_svy so available to svy stat functions

--- a/R/summarise.r
+++ b/R/summarise.r
@@ -6,7 +6,7 @@ summarise.tbl_svy <- function(.data, ..., .by = NULL, .groups = NULL, .unpack = 
   # Can't just pass `.by` to dplyr because we need to calculate survey statistics per group
   if (!all(sapply(.by, rlang::quo_is_null))) {
     .data <- group_by(.data, across(!!!.by))
-    return(summarise(.data, !!!.dots, .groups = .groups, .unpack = .unpack))
+    return(ungroup(summarise(.data, !!!.dots, .groups = .groups, .unpack = .unpack)))
   }
 
   if (is_lazy_svy(.data)) .data <- localize_lazy_svy(.data, .dots)

--- a/tests/testthat/test_dplyr_verbs.R
+++ b/tests/testthat/test_dplyr_verbs.R
@@ -35,7 +35,8 @@ test_that("mutate can handle survey summaries", {
 test_that("mutate can handle .by", {
   explicit_group_by <- dstrata %>%
     group_by(awards) %>%
-    mutate(x = survey_mean(api99))
+    mutate(x = survey_mean(api99)) %>%
+    ungroup()
 
   .by_arg <- dstrata %>%
     mutate(x = survey_mean(api99), .by = awards)
@@ -46,7 +47,8 @@ test_that("mutate can handle .by", {
 test_that("mutate can handle multiple .by", {
   explicit_group_by <- dstrata %>%
     group_by(name, awards) %>%
-    mutate(x = survey_mean(api99))
+    mutate(x = survey_mean(api99)) %>%
+    ungroup()
 
   .by_arg <- dstrata %>%
     mutate(x = survey_mean(api99), .by = c(name, awards))


### PR DESCRIPTION
Within `dplyr`, the return from a statement with a `.by` argument will be ungrouped. At present the same statement using `srvyr` returns grouped data.

This change fixes this (and updates the associated tests) to ensure behavioural consistency between the two packages.