### PR TITLE
`as_survey_rep()`: prettier printing, and keeping up with 'survey' 4.5 changes

### DIFF
--- a/R/as_survey_rep.r
+++ b/R/as_survey_rep.r
@@ -85,6 +85,15 @@ as_survey_rep.data.frame <-
     fpc <- srvyr_select_vars(rlang::enquo(fpc), .data)
     type <- if (missing(type)) type[1] else type
 
+    if (type=="ACS"){
+      if (missing(mse) && !mse){
+        mse <- TRUE
+        message("mse=TRUE assumed for type=\"ACS\"")
+      } else if (!mse){
+        warning("The ACS uses MSE standard errors but you have specified mse=FALSE")
+      }
+    }
+
     out <- survey::svrepdesign(
       variables = variables,
       repweights = repweights,

--- a/R/as_survey_rep.r
+++ b/R/as_survey_rep.r
@@ -79,7 +79,7 @@ as_survey_rep.data.frame <-
            rscales = NULL, fpc = NULL, fpctype = c("fraction", "correction"),
            mse = getOption("survey.replicates.mse"), degf = NULL, ...) {
     variables <- srvyr_select_vars(rlang::enquo(variables), .data)
-    repweights_label <- rlang::as_label(rlang::enquo(repweights))
+    repweights_label <- rlang::as_label(rlang::enexpr(repweights))
     repweights <- srvyr_select_vars(rlang::enquo(repweights), .data)
     weights <- srvyr_select_vars(rlang::enquo(weights), .data)
     fpc <- srvyr_select_vars(rlang::enquo(fpc), .data)

--- a/R/as_survey_rep.r
+++ b/R/as_survey_rep.r
@@ -79,6 +79,7 @@ as_survey_rep.data.frame <-
            rscales = NULL, fpc = NULL, fpctype = c("fraction", "correction"),
            mse = getOption("survey.replicates.mse"), degf = NULL, ...) {
     variables <- srvyr_select_vars(rlang::enquo(variables), .data)
+    repweights_label <- rlang::as_label(rlang::enquo(repweights))
     repweights <- srvyr_select_vars(rlang::enquo(repweights), .data)
     weights <- srvyr_select_vars(rlang::enquo(weights), .data)
     fpc <- srvyr_select_vars(rlang::enquo(fpc), .data)
@@ -103,7 +104,7 @@ as_survey_rep.data.frame <-
 
     out <- as_tbl_svy(
       out,
-      list(repweights = repweights,  weights = weights, fpc = fpc)
+      list(repweights = repweights_label, weights = weights, fpc = fpc)
     )
     preserve_groups(out, .data)
   }

--- a/R/tbl-svy.r
+++ b/R/tbl-svy.r
@@ -153,6 +153,11 @@ print.quoteless_text <- function(x, ...) {
 strip_varlist_formula <- function(vars) {
   lapply(vars, function(x) {
     if (length(x) == 0) return(x)
-    as.character(x)[-1] # First pos is either ~ or +
+    if ((length(x) == 1) && is.character(x)) {
+      return(x)
+    }
+    if (inherits(x, "formula")) {
+      as.character(x)[-1] # First pos is either ~ or +
+    }
   })
 }

--- a/tests/testthat/test_as_survey_rep.r
+++ b/tests/testthat/test_as_survey_rep.r
@@ -197,7 +197,8 @@ colnames(sdr_factors) <- paste0("REP_", 1:4)
 
 sdr_design <- svrepdesign(
   data = sdr_sample,
-  type = "successive-difference",
+  type = "successive-difference", 
+  mse = TRUE,
   weights = ~ weights,
   repweights = sdr_factors,
   combined = FALSE,
@@ -208,11 +209,13 @@ sdr_srvyr <- cbind(sdr_sample, as.data.frame(sdr_factors)) %>%
   as_survey_rep(repweights = starts_with("REP_"),
                 weights = "weights",
                 type = "successive-difference",
+                mse = TRUE,
                 combined = FALSE)
 acs_srvyr <- cbind(sdr_sample, as.data.frame(sdr_factors)) %>%
   as_survey_rep(repweights = starts_with("REP_"),
                 weights = "weights",
-                type = "ACS",
+                type = "ACS", 
+                mse = TRUE,
                 combined = FALSE)
 
 out_survey <- svymean(~api00, sdr_design)
@@ -227,6 +230,24 @@ test_that("as_survey_rep works when using SDR/ACS method of replicate weights", 
                c(out_srvyr_sdr[[1]][[1]], out_srvyr_sdr[[2]][[1]]))
   expect_equal(c(out_survey[[1]], sqrt(attr(out_survey, "var"))),
                c(out_srvyr_acs[[1]][[1]], out_srvyr_acs[[2]][[1]]))
+})
+test_that("as_survey_rep handles `mse` with `type='ACS'`, similar to 'survey'", {
+  expect_message(
+    object = cbind(sdr_sample, as.data.frame(sdr_factors)) %>%
+      as_survey_rep(repweights = starts_with("REP_"),
+                    weights = "weights",
+                    type = "ACS", 
+                    combined = FALSE),
+    expected = "mse=TRUE assumed"
+  )
+  expect_warning(
+    object = cbind(sdr_sample, as.data.frame(sdr_factors)) %>%
+      as_survey_rep(repweights = starts_with("REP_"),
+                    weights = "weights",
+                    type = "ACS", mse = FALSE,
+                    combined = FALSE),
+    expected = "The ACS uses MSE standard errors"
+  )
 })
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
This PR is focused on `as_survey_rep()` and addresses issues #201 and #202.

## Keeping up with the 'survey' package when using `type = "ACS"`
For #202, it adds new logic into `as_survey_rep()` so that we have the same behavior as `survey::svrepdesign()` when using `type = "ACS"`. It adds a corresponding unit test. While I was at it, I also updated separate unit tests related to `type = "ACS"` so that we explicitly set the `mse` argument in calls to `as_survey_rep()`, to avoid issues caused by this update.

## Prettier printing of `repweights` in output
A couple small changes to the processing of the replicate weight argument in `as_survey_rep()` should yield prettier printed output than the current formula output, which tended to get unwieldy in the common setting where users have lots of replicate weights. With this update, we now use rlang to capture selectors and display those. So we now have printing that looks like this:

```
Call: Called via srvyr
Balanced Repeated Replicates with 1000 replicates.
Sampling variables:
  - repweights: `starts_with("repweight")` 
  - weights: w 
Data variables: 
  - y (int)
```