### PR TITLE
Add na_weights as argument for as_survey_design

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     magrittr,
     methods,
     rlang,
-    survey (>= 4.1),
+    survey (>= 4.5),
     tibble,
     tidyr,
     tidyselect,
@@ -41,5 +41,5 @@ Suggests:
     covr
 Encoding: UTF-8
 VignetteBuilder: knitr
-RoxygenNote: 7.3.3
 Language: en-US
+Config/roxygen2/version: 8.0.0

--- a/R/as_survey_design.r
+++ b/R/as_survey_design.r
@@ -28,6 +28,7 @@
 #' approximation. An object of class ppsmat to use the Horvitz-Thompson estimator.
 #' @param variance For pps without replacement, use variance="YG" for the Yates-Grundy estimator
 #' instead of the Horvitz-Thompson estimator
+#' @param na_weights How to handle missing values in weights. "fail" will throw an error, "warn" will throw a warning, and "allow" will allow them. See \code{\link[survey]{svydesign}} for more details.
 #' @param ... ignored
 #' @return An object of class \code{tbl_svy}
 #' @examples
@@ -84,7 +85,7 @@ as_survey_design.data.frame <-
   function(.data, ids = NULL, probs = NULL, strata = NULL,
            variables = NULL, fpc = NULL, nest = FALSE,
            check_strata = !nest, weights = NULL, pps = FALSE,
-           variance = c("HT", "YG"), ...) {
+           variance = c("HT", "YG"), na_weights = c("fail", "warn", "allow"), ...) {
 
   ids <- srvyr_select_vars(rlang::enquo(ids), .data, check_ids = TRUE)
   probs <- srvyr_select_vars(rlang::enquo(probs), .data)
@@ -95,7 +96,7 @@ as_survey_design.data.frame <-
 
   if (is.null(ids)) ids <- ~1
   out <- survey::svydesign(
-    ids, probs, strata, variables, fpc, .data, nest, check_strata, weights, pps
+    ids, probs, strata, variables, fpc, .data, nest, check_strata, weights, pps, na_weights = na_weights
   )
 
   out <- as_tbl_svy(
@@ -104,7 +105,7 @@ as_survey_design.data.frame <-
   )
 
   preserve_groups(out, .data)
-}
+  }
 
 #' @export
 #' @rdname as_survey_design
@@ -118,7 +119,7 @@ as_survey_design.tbl_lazy <-
   function(.data, ids = NULL, probs = NULL, strata = NULL,
            variables = NULL, fpc = NULL, nest = FALSE,
            check_strata = !nest, weights = NULL, pps = FALSE,
-           variance = c("HT", "YG"), ...) {
+           variance = c("HT", "YG"), na_weights = "fail", ...) {
 
     ids <- rlang::enquo(ids)
     probs <- rlang::enquo(probs)
@@ -140,7 +141,7 @@ as_survey_design.tbl_lazy <-
 
     if (is.null(ids)) ids <- ~1
     out <- survey::svydesign(
-      ids, probs, strata, variables, fpc, survey_vars_local, nest, check_strata, weights, pps
+      ids, probs, strata, variables, fpc, survey_vars_local, nest, check_strata, weights, pps, na_weights = na_weights
     )
     out$variables <- .data
 

--- a/man/as_survey_design.Rd
+++ b/man/as_survey_design.Rd
@@ -21,6 +21,7 @@ as_survey_design(.data, ...)
   weights = NULL,
   pps = FALSE,
   variance = c("HT", "YG"),
+  na_weights = c("fail", "warn", "allow"),
   ...
 )
 
@@ -38,6 +39,7 @@ as_survey_design(.data, ...)
   weights = NULL,
   pps = FALSE,
   variance = c("HT", "YG"),
+  na_weights = "fail",
   ...
 )
 }
@@ -71,6 +73,8 @@ approximation. An object of class ppsmat to use the Horvitz-Thompson estimator.}
 
 \item{variance}{For pps without replacement, use variance="YG" for the Yates-Grundy estimator
 instead of the Horvitz-Thompson estimator}
+
+\item{na_weights}{How to handle missing values in weights. "fail" will throw an error, "warn" will throw a warning, and "allow" will allow them. See \code{\link[survey]{svydesign}} for more details.}
 }
 \value{
 An object of class \code{tbl_svy}

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -25,6 +25,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{dplyr}{\code{\link[dplyr]{across}}, \code{\link[dplyr]{c_across}}, \code{\link[dplyr:context]{cur_column}}, \code{\link[dplyr:deprec-context]{cur_data}}, \code{\link[dplyr:context]{cur_group}}, \code{\link[dplyr:context]{cur_group_id}}, \code{\link[dplyr]{group_map}}, \code{\link[dplyr:group_map]{group_modify}}, \code{\link[dplyr]{group_nest}}, \code{\link[dplyr]{group_split}}, \code{\link[dplyr:group_map]{group_walk}}, \code{\link[dplyr:context]{n}}, \code{\link[dplyr]{nest_by}}, \code{\link[dplyr]{reframe}}}
+  \item{dplyr}{\code{\link[dplyr:across]{across()}}, \code{\link[dplyr:c_across]{c_across()}}, \code{\link[dplyr:cur_column]{cur_column()}}, \code{\link[dplyr:cur_data]{cur_data()}}, \code{\link[dplyr:cur_group]{cur_group()}}, \code{\link[dplyr:cur_group_id]{cur_group_id()}}, \code{\link[dplyr:group_map]{group_map()}}, \code{\link[dplyr:group_modify]{group_modify()}}, \code{\link[dplyr:group_nest]{group_nest()}}, \code{\link[dplyr:group_split]{group_split()}}, \code{\link[dplyr:group_walk]{group_walk()}}, \code{\link[dplyr:n]{n()}}, \code{\link[dplyr:nest_by]{nest_by()}}, \code{\link[dplyr:reframe]{reframe()}}}
 }}
 

--- a/man/srvyr.Rd
+++ b/man/srvyr.Rd
@@ -72,6 +72,7 @@ Useful links:
 
 Authors:
 \itemize{
+  \item Greg Freedman Ellis \email{greg.freedman@gmail.com}
   \item Ben Schneider [contributor]
 }
 

--- a/tests/testthat/test_as_survey_design.r
+++ b/tests/testthat/test_as_survey_design.r
@@ -25,3 +25,28 @@ test_that("as_survey_design preserves groups", {
     "Not all grouping variables exist in survey"
   )
 })
+
+test_that("as_survey_design can handle NA weights", {
+  data(api, package = "survey")
+
+  apistrat_na <- apistrat
+  apistrat_na$pw[1:5] <- NA
+
+  expect_warning(
+    apistrat_na |>
+      as_survey_design(strata = stype, weights = pw, na_weights = "warn"),
+    "missing values in weights; records will be dropped"
+  )
+
+  expect_error(
+    apistrat_na |>
+      as_survey_design(strata = stype, weights = pw),
+    "missing values in weights and na_weights='fail'"
+  )
+
+  expect_error(
+    apistrat_na |>
+      as_survey_design(strata = stype, weights = pw, na_weights = "fail"),
+    "missing values in weights and na_weights='fail'"
+  )
+})


### PR DESCRIPTION
- Add na_weights as argument in `as_survey_design()` to mirror new addition in `survey::svydesign()` to address #210 
- This necessitates bumping minimum version of survey package
- Added tests
- Updated documentation, note: some unrelated files got updated via `devtools::document()` because of updated version of roxygen